### PR TITLE
Add main menu to select games

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1,19 +1,122 @@
+:root {
+  color-scheme: light dark;
+}
+
 .app {
   min-height: 100vh;
+  background: radial-gradient(circle at top, #f8fbff, #dce7ff);
   display: grid;
   place-items: center;
+  padding: clamp(2rem, 4vw, 4rem);
+  font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  color: #0f172a;
+}
+
+.menu {
+  width: min(960px, 100%);
+  background-color: rgba(255, 255, 255, 0.85);
+  border-radius: 1.5rem;
+  box-shadow: 0 24px 60px rgba(15, 23, 42, 0.15);
+  padding: clamp(2rem, 5vw, 3rem);
+  backdrop-filter: blur(8px);
+}
+
+.menu__header {
   text-align: center;
-  gap: 1rem;
-  padding: 2rem;
+  margin-bottom: clamp(1.5rem, 4vw, 2.5rem);
 }
 
-.app h1 {
+.menu__header h1 {
   font-size: clamp(2.5rem, 6vw, 3.5rem);
-  margin: 0;
+  margin: 0 0 0.5rem;
+  letter-spacing: -0.03em;
 }
 
-.app p {
+.menu__header p {
   margin: 0;
-  color: #555;
-  font-size: 1.1rem;
+  font-size: clamp(1.05rem, 2.5vw, 1.2rem);
+  color: #475569;
+}
+
+.menu__grid {
+  display: grid;
+  gap: clamp(1rem, 3vw, 1.75rem);
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+}
+
+.menu__card {
+  background: linear-gradient(145deg, rgba(241, 245, 255, 0.85), rgba(226, 232, 255, 0.75));
+  border-radius: 1.25rem;
+  padding: clamp(1.25rem, 3vw, 1.75rem);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.65);
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  border: 1px solid rgba(99, 102, 241, 0.15);
+}
+
+.menu__card h2 {
+  margin: 0;
+  font-size: clamp(1.3rem, 3vw, 1.6rem);
+  color: #1e293b;
+}
+
+.menu__card p {
+  margin: 0;
+  color: #475569;
+  font-size: 1rem;
+  line-height: 1.6;
+}
+
+.menu__card button {
+  align-self: flex-start;
+  background: linear-gradient(135deg, #6366f1, #4f46e5);
+  border: none;
+  border-radius: 999px;
+  color: #fff;
+  cursor: pointer;
+  font-size: 0.95rem;
+  font-weight: 600;
+  padding: 0.75rem 1.75rem;
+  transition: transform 0.15s ease, box-shadow 0.15s ease, filter 0.15s ease;
+}
+
+.menu__card button:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 18px 35px rgba(79, 70, 229, 0.2);
+}
+
+.menu__card button:focus-visible {
+  outline: 3px solid rgba(99, 102, 241, 0.45);
+  outline-offset: 3px;
+}
+
+@media (prefers-color-scheme: dark) {
+  .app {
+    background: radial-gradient(circle at top, #111827, #0f172a);
+    color: #e2e8f0;
+  }
+
+  .menu {
+    background-color: rgba(15, 23, 42, 0.75);
+    box-shadow: 0 24px 60px rgba(2, 6, 23, 0.55);
+  }
+
+  .menu__card {
+    background: linear-gradient(145deg, rgba(30, 41, 59, 0.95), rgba(15, 23, 42, 0.9));
+    border: 1px solid rgba(99, 102, 241, 0.35);
+    box-shadow: inset 0 1px 0 rgba(148, 163, 184, 0.15);
+  }
+
+  .menu__card h2 {
+    color: #e2e8f0;
+  }
+
+  .menu__card p {
+    color: #cbd5f5;
+  }
+
+  .menu__card button {
+    filter: brightness(1.05);
+  }
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,8 +1,54 @@
+import { useState } from 'react'
 import './App.css'
 import ReactionTest from './ReactionTest'
 
+type GameId = 'reaction-test'
+
+interface GameDefinition {
+  id: GameId
+  name: string
+  description: string
+  startLabel: string
+}
+
+const games: GameDefinition[] = [
+  {
+    id: 'reaction-test',
+    name: 'Reaktionstest',
+    description:
+      'Hvor hurtigt kan du reagere? Klik, så snart skærmen skifter farve, og se dine bedste tider.',
+    startLabel: 'Start reaktionstest',
+  },
+]
+
 function App() {
-  return <ReactionTest />
+  const [activeGame, setActiveGame] = useState<GameId | null>(null)
+
+  if (activeGame === 'reaction-test') {
+    return <ReactionTest onExit={() => setActiveGame(null)} />
+  }
+
+  return (
+    <main className="app">
+      <div className="menu">
+        <header className="menu__header">
+          <h1>Fokus</h1>
+          <p>Vælg et spil for at komme i gang.</p>
+        </header>
+        <section className="menu__grid">
+          {games.map((game) => (
+            <article key={game.id} className="menu__card">
+              <h2>{game.name}</h2>
+              <p>{game.description}</p>
+              <button type="button" onClick={() => setActiveGame(game.id)}>
+                {game.startLabel}
+              </button>
+            </article>
+          ))}
+        </section>
+      </div>
+    </main>
+  )
 }
 
 export default App

--- a/src/ReactionTest.tsx
+++ b/src/ReactionTest.tsx
@@ -24,7 +24,11 @@ const textByPhase = (phase: Phase, reactionTime: number | null) => {
   }
 }
 
-export default function ReactionTest() {
+interface ReactionTestProps {
+  onExit?: () => void
+}
+
+export default function ReactionTest({ onExit }: ReactionTestProps) {
   const [phase, setPhase] = useState<Phase>('waiting')
   const [reactionTime, setReactionTime] = useState<number | null>(null)
   const [highScores, setHighScores] = useState<number[]>([])
@@ -153,6 +157,36 @@ export default function ReactionTest() {
           </ol>
         )}
       </div>
+      {onExit && (
+        <button
+          onClick={(event) => {
+            event.stopPropagation()
+            onExit()
+          }}
+          style={{
+            backgroundColor: 'rgba(0, 0, 0, 0.45)',
+            border: '1px solid rgba(255, 255, 255, 0.4)',
+            borderRadius: '999px',
+            color: '#fff',
+            cursor: 'pointer',
+            fontFamily: 'inherit',
+            fontSize: '0.9rem',
+            fontWeight: 600,
+            padding: '0.5rem 1.25rem',
+            position: 'absolute',
+            right: '1rem',
+            top: '1rem',
+            transition: 'background-color 0.2s ease, border-color 0.2s ease',
+          }}
+          onMouseDown={(event) => event.stopPropagation()}
+          onTouchStart={(event) => event.stopPropagation()}
+          onKeyDown={(event) => {
+            event.stopPropagation()
+          }}
+        >
+          Tilbage til menu
+        </button>
+      )}
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- add a main menu screen that lets players choose which game to launch
- style the menu with responsive cards and dark mode tweaks
- allow exiting the reaction test to return to the menu

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e8d91a4a3c832fa00fe55d9c59f568