### PR TITLE
feat(memory): add Memory game with difficulties and highscores

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,3 +19,8 @@ Et React + TypeScript projekt oprettet med Vite.
 - `npm run build` – typechecker projektet og bygger en produktionklar version i `dist/`.
 - `npm run preview` – server den byggede app lokalt.
 - `npm run test` – placeholder der markerer, at tests endnu ikke er sat op.
+
+## Spil
+
+- **Reaktionstest** – klik så hurtigt som muligt, når skærmen skifter farve, og jagt dine hurtigste reaktionstider.
+- **Memory** – vend to kort ad gangen og find alle par. Du kan vælge mellem tre sværhedsgrader: Let (4 × 4, 8 par), Mellem (5 × 4, 10 par) og Svær (6 × 4, 12 par). Spillet holder styr på dine bedste tider og færreste træk pr. niveau via localStorage.

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
   },
   "dependencies": {
     "react": "^18.3.1",
-    "react-dom": "^18.3.1"
+    "react-dom": "^18.3.1",
+    "react-router-dom": "^6.26.2"
   },
   "devDependencies": {
     "@types/react": "^18.3.3",

--- a/src/App.css
+++ b/src/App.css
@@ -68,25 +68,30 @@
   line-height: 1.6;
 }
 
-.menu__card button {
+.menu__card button,
+.menu__card a {
   align-self: flex-start;
   background: linear-gradient(135deg, #6366f1, #4f46e5);
   border: none;
   border-radius: 999px;
   color: #fff;
   cursor: pointer;
+  display: inline-flex;
   font-size: 0.95rem;
   font-weight: 600;
   padding: 0.75rem 1.75rem;
+  text-decoration: none;
   transition: transform 0.15s ease, box-shadow 0.15s ease, filter 0.15s ease;
 }
 
-.menu__card button:hover {
+.menu__card button:hover,
+.menu__card a:hover {
   transform: translateY(-1px);
   box-shadow: 0 18px 35px rgba(79, 70, 229, 0.2);
 }
 
-.menu__card button:focus-visible {
+.menu__card button:focus-visible,
+.menu__card a:focus-visible {
   outline: 3px solid rgba(99, 102, 241, 0.45);
   outline-offset: 3px;
 }
@@ -116,7 +121,8 @@
     color: #cbd5f5;
   }
 
-  .menu__card button {
+  .menu__card button,
+  .menu__card a {
     filter: brightness(1.05);
   }
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,53 +1,27 @@
-import { useState } from 'react'
+import { Navigate, Outlet, Route, Routes } from 'react-router-dom'
 import './App.css'
-import ReactionTest from './ReactionTest'
+import Home from './screens/Home'
+import MemoryGame from './screens/MemoryGame'
+import ReactionTestScreen from './screens/ReactionTestScreen'
 
-type GameId = 'reaction-test'
-
-interface GameDefinition {
-  id: GameId
-  name: string
-  description: string
-  startLabel: string
-}
-
-const games: GameDefinition[] = [
-  {
-    id: 'reaction-test',
-    name: 'Reaktionstest',
-    description:
-      'Hvor hurtigt kan du reagere? Klik, så snart skærmen skifter farve, og se dine bedste tider.',
-    startLabel: 'Start reaktionstest',
-  },
-]
-
-function App() {
-  const [activeGame, setActiveGame] = useState<GameId | null>(null)
-
-  if (activeGame === 'reaction-test') {
-    return <ReactionTest onExit={() => setActiveGame(null)} />
-  }
-
+function AppLayout() {
   return (
     <main className="app">
-      <div className="menu">
-        <header className="menu__header">
-          <h1>Fokus</h1>
-          <p>Vælg et spil for at komme i gang.</p>
-        </header>
-        <section className="menu__grid">
-          {games.map((game) => (
-            <article key={game.id} className="menu__card">
-              <h2>{game.name}</h2>
-              <p>{game.description}</p>
-              <button type="button" onClick={() => setActiveGame(game.id)}>
-                {game.startLabel}
-              </button>
-            </article>
-          ))}
-        </section>
-      </div>
+      <Outlet />
     </main>
+  )
+}
+
+function App() {
+  return (
+    <Routes>
+      <Route element={<AppLayout />}>
+        <Route index element={<Home />} />
+        <Route path="memory" element={<MemoryGame />} />
+      </Route>
+      <Route path="reaction-test" element={<ReactionTestScreen />} />
+      <Route path="*" element={<Navigate to="/" replace />} />
+    </Routes>
   )
 }
 

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,10 +1,13 @@
 import React from 'react'
 import ReactDOM from 'react-dom/client'
+import { BrowserRouter } from 'react-router-dom'
 import App from './App.tsx'
 import './index.css'
 
 ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
   <React.StrictMode>
-    <App />
+    <BrowserRouter>
+      <App />
+    </BrowserRouter>
   </React.StrictMode>,
 )

--- a/src/screens/Home.tsx
+++ b/src/screens/Home.tsx
@@ -1,0 +1,97 @@
+import { useEffect, useState } from 'react'
+import { Link } from 'react-router-dom'
+import { loadHighscores, type MemoryHighscores } from '../utils/memoryHighscores'
+
+interface GameDefinition {
+  id: string
+  name: string
+  description: string
+  path: string
+  startLabel: string
+}
+
+const games: GameDefinition[] = [
+  {
+    id: 'reaction-test',
+    name: 'Reaktionstest',
+    description:
+      'Hvor hurtigt kan du reagere? Klik, så snart skærmen skifter farve, og se dine bedste tider.',
+    path: '/reaction-test',
+    startLabel: 'Start reaktionstest',
+  },
+  {
+    id: 'memory',
+    name: 'Memory',
+    description:
+      'Vend to kort ad gangen og find alle par hurtigst muligt. Flere sværhedsgrader og highscores.',
+    path: '/memory',
+    startLabel: 'Start memory',
+  },
+]
+
+export default function Home() {
+  const [highscores, setHighscores] = useState<MemoryHighscores>(() => loadHighscores())
+
+  useEffect(() => {
+    const updateScores = () => {
+      setHighscores(loadHighscores())
+    }
+
+    updateScores()
+
+    if (typeof window === 'undefined') {
+      return
+    }
+
+    window.addEventListener('storage', updateScores)
+    return () => {
+      window.removeEventListener('storage', updateScores)
+    }
+  }, [])
+
+  const easyScore = highscores.easy
+  const hasEasyScore = easyScore.bestMoves !== null && easyScore.bestTimeMs !== null
+
+  return (
+    <div className="menu">
+      <header className="menu__header">
+        <h1>Fokus</h1>
+        <p>Vælg et spil for at komme i gang.</p>
+      </header>
+
+      <section
+        style={{
+          backgroundColor: 'rgba(99, 102, 241, 0.08)',
+          borderRadius: '1rem',
+          marginBottom: '1.5rem',
+          padding: '1rem 1.25rem',
+          fontSize: '0.95rem',
+          lineHeight: 1.6,
+        }}
+      >
+        <strong style={{ display: 'block', marginBottom: '0.25rem' }}>
+          Bedste hukommelses-score (Let):
+        </strong>
+        {hasEasyScore ? (
+          <span>
+            {easyScore.bestMoves} træk · {Math.max(0, Math.floor(easyScore.bestTimeMs! / 1000))} s
+          </span>
+        ) : (
+          <span>–</span>
+        )}
+      </section>
+
+      <section className="menu__grid">
+        {games.map((game) => (
+          <article key={game.id} className="menu__card">
+            <h2>{game.name}</h2>
+            <p>{game.description}</p>
+            <Link to={game.path}>
+              {game.startLabel}
+            </Link>
+          </article>
+        ))}
+      </section>
+    </div>
+  )
+}

--- a/src/screens/MemoryGame.tsx
+++ b/src/screens/MemoryGame.tsx
@@ -1,0 +1,489 @@
+import { useEffect, useMemo, useRef, useState, type ChangeEvent } from 'react'
+import {
+  loadHighscores,
+  saveHighscores,
+  type MemoryDifficulty,
+  type MemoryHighscores,
+} from '../utils/memoryHighscores'
+
+interface MemoryCard {
+  id: number
+  symbol: string
+  revealed: boolean
+  matched: boolean
+}
+
+interface DifficultyConfig {
+  label: string
+  columns: number
+  pairs: number
+}
+
+const difficulties: Record<MemoryDifficulty, DifficultyConfig> = {
+  easy: { label: 'Let (4 × 4)', columns: 4, pairs: 8 },
+  medium: { label: 'Mellem (5 × 4)', columns: 5, pairs: 10 },
+  hard: { label: 'Svær (6 × 4)', columns: 6, pairs: 12 },
+}
+
+const symbols = [
+  '🍎',
+  '🍌',
+  '🍇',
+  '🍉',
+  '🍓',
+  '🥑',
+  '🥕',
+  '🍄',
+  '🍔',
+  '🍕',
+  '🍣',
+  '🍩',
+  '⚽',
+  '🚗',
+  '✈️',
+  '🎧',
+  '📚',
+  '🧩',
+]
+
+const HIDE_DELAY_MS = 700
+
+function shuffle<T>(list: T[]): T[] {
+  const array = [...list]
+  for (let index = array.length - 1; index > 0; index -= 1) {
+    const randomIndex = Math.floor(Math.random() * (index + 1))
+    ;[array[index], array[randomIndex]] = [array[randomIndex], array[index]]
+  }
+  return array
+}
+
+function createDeck(difficulty: MemoryDifficulty): MemoryCard[] {
+  const { pairs } = difficulties[difficulty]
+  const availableSymbols = shuffle(symbols)
+  const selectedSymbols = availableSymbols.slice(0, pairs)
+  const deckSymbols = shuffle([...selectedSymbols, ...selectedSymbols])
+  return deckSymbols.map((symbol, index) => ({
+    id: index,
+    symbol,
+    revealed: false,
+    matched: false,
+  }))
+}
+
+function formatSeconds(ms: number): number {
+  return Math.max(0, Math.floor(ms / 1000))
+}
+
+export default function MemoryGame() {
+  const [difficulty, setDifficulty] = useState<MemoryDifficulty>('easy')
+  const [cards, setCards] = useState<MemoryCard[]>(() => createDeck('easy'))
+  const [selectedCards, setSelectedCards] = useState<number[]>([])
+  const [moves, setMoves] = useState(0)
+  const [elapsedMs, setElapsedMs] = useState(0)
+  const [isLocked, setIsLocked] = useState(false)
+  const [isComplete, setIsComplete] = useState(false)
+  const [highscores, setHighscores] = useState<MemoryHighscores>(() => loadHighscores())
+  const [lastMismatch, setLastMismatch] = useState<{ first: number; second: number } | null>(
+    null,
+  )
+
+  const startTimestampRef = useRef<number | null>(null)
+  const timerRef = useRef<number | null>(null)
+  const hideTimeoutRef = useRef<number | null>(null)
+  const [isTimerRunning, setIsTimerRunning] = useState(false)
+
+  useEffect(() => {
+    if (!isTimerRunning) {
+      if (timerRef.current !== null) {
+        window.clearInterval(timerRef.current)
+        timerRef.current = null
+      }
+      return
+    }
+
+    if (timerRef.current !== null) {
+      return
+    }
+
+    timerRef.current = window.setInterval(() => {
+      if (startTimestampRef.current !== null) {
+        setElapsedMs(performance.now() - startTimestampRef.current)
+      }
+    }, 250)
+
+    return () => {
+      if (timerRef.current !== null) {
+        window.clearInterval(timerRef.current)
+        timerRef.current = null
+      }
+    }
+  }, [isTimerRunning])
+
+  useEffect(() => {
+    return () => {
+      if (timerRef.current !== null) {
+        window.clearInterval(timerRef.current)
+      }
+      if (hideTimeoutRef.current !== null) {
+        window.clearTimeout(hideTimeoutRef.current)
+      }
+    }
+  }, [])
+
+  const currentHighscore = highscores[difficulty]
+
+  const gridTemplateColumns = useMemo(() => {
+    const { columns } = difficulties[difficulty]
+    return `repeat(${columns}, minmax(64px, 1fr))`
+  }, [difficulty])
+
+  const handleNewGame = (nextDifficulty?: MemoryDifficulty) => {
+    const targetDifficulty = nextDifficulty ?? difficulty
+
+    if (targetDifficulty !== difficulty) {
+      setDifficulty(targetDifficulty)
+    }
+
+    if (hideTimeoutRef.current !== null) {
+      window.clearTimeout(hideTimeoutRef.current)
+      hideTimeoutRef.current = null
+    }
+
+    if (timerRef.current !== null) {
+      window.clearInterval(timerRef.current)
+      timerRef.current = null
+    }
+
+    setCards(createDeck(targetDifficulty))
+    setSelectedCards([])
+    setMoves(0)
+    setElapsedMs(0)
+    setIsLocked(false)
+    setIsComplete(false)
+    setLastMismatch(null)
+    setIsTimerRunning(false)
+    startTimestampRef.current = null
+  }
+
+  const updateHighscores = (movesCount: number, timeMs: number, finishedDifficulty: MemoryDifficulty) => {
+    setHighscores((previous) => {
+      const next: MemoryHighscores = {
+        easy: { ...previous.easy },
+        medium: { ...previous.medium },
+        hard: { ...previous.hard },
+      }
+
+      const entry = next[finishedDifficulty]
+      let hasChanged = false
+
+      if (entry.bestMoves === null || movesCount < entry.bestMoves) {
+        entry.bestMoves = movesCount
+        hasChanged = true
+      }
+
+      if (entry.bestTimeMs === null || timeMs < entry.bestTimeMs) {
+        entry.bestTimeMs = timeMs
+        hasChanged = true
+      }
+
+      if (hasChanged) {
+        saveHighscores(next)
+        return next
+      }
+
+      return previous
+    })
+  }
+
+  const finishGame = (finalMoves: number) => {
+    const finalTime = startTimestampRef.current
+      ? performance.now() - startTimestampRef.current
+      : elapsedMs
+    setElapsedMs(finalTime)
+    setIsTimerRunning(false)
+    setIsComplete(true)
+    startTimestampRef.current = null
+    updateHighscores(finalMoves, finalTime, difficulty)
+  }
+
+  const handleCardClick = (cardId: number) => {
+    if (isLocked || isComplete) {
+      return
+    }
+
+    const card = cards.find((item) => item.id === cardId)
+    if (!card || card.revealed || card.matched) {
+      return
+    }
+
+    if (selectedCards.length === 0 && lastMismatch) {
+      setLastMismatch(null)
+    }
+
+    if (!isTimerRunning) {
+      startTimestampRef.current = performance.now()
+      setElapsedMs(0)
+      setIsTimerRunning(true)
+    }
+
+    const revealedCards = cards.map((item) =>
+      item.id === cardId ? { ...item, revealed: true } : item,
+    )
+    setCards(revealedCards)
+
+    const nextSelected = [...selectedCards, cardId]
+    setSelectedCards(nextSelected)
+
+    if (nextSelected.length !== 2) {
+      return
+    }
+
+    const [firstId, secondId] = nextSelected
+    const firstCard = revealedCards.find((item) => item.id === firstId)
+    const secondCard = revealedCards.find((item) => item.id === secondId)
+
+    if (!firstCard || !secondCard) {
+      setSelectedCards([])
+      return
+    }
+
+    const nextMoves = moves + 1
+    setMoves(nextMoves)
+
+    if (firstCard.symbol === secondCard.symbol) {
+      const matchedCards = revealedCards.map((item) =>
+        item.id === firstId || item.id === secondId
+          ? { ...item, matched: true }
+          : item,
+      )
+      setCards(matchedCards)
+      setSelectedCards([])
+
+      const allMatched = matchedCards.every((item) => item.matched)
+      if (allMatched) {
+        finishGame(nextMoves)
+      }
+
+      return
+    }
+
+    setIsLocked(true)
+    setSelectedCards([])
+
+    if (hideTimeoutRef.current !== null) {
+      window.clearTimeout(hideTimeoutRef.current)
+    }
+
+    hideTimeoutRef.current = window.setTimeout(() => {
+      setCards((currentCards) =>
+        currentCards.map((item) =>
+          item.id === firstId || item.id === secondId
+            ? { ...item, revealed: false }
+            : item,
+        ),
+      )
+      setIsLocked(false)
+      setLastMismatch({ first: firstId, second: secondId })
+    }, HIDE_DELAY_MS)
+  }
+
+  const handleUndo = () => {
+    if (!lastMismatch || isLocked || isComplete || selectedCards.length > 0) {
+      return
+    }
+
+    const { first } = lastMismatch
+    setLastMismatch(null)
+    setMoves((previous) => (previous > 0 ? previous - 1 : 0))
+    setIsLocked(false)
+    setCards((currentCards) =>
+      currentCards.map((card) =>
+        card.id === first ? { ...card, revealed: true } : card,
+      ),
+    )
+    setSelectedCards([first])
+
+    if (!isTimerRunning) {
+      startTimestampRef.current = performance.now() - elapsedMs
+      setIsTimerRunning(true)
+    }
+  }
+
+  const handleDifficultyChange = (event: ChangeEvent<HTMLSelectElement>) => {
+    const nextDifficulty = event.target.value as MemoryDifficulty
+    handleNewGame(nextDifficulty)
+  }
+
+  return (
+    <section className="menu" style={{ width: 'min(960px, 100%)' }}>
+      <header className="menu__header" style={{ marginBottom: '1.25rem' }}>
+        <h1>Memory</h1>
+        <p>Vend kortene og find alle par hurtigst muligt.</p>
+      </header>
+
+      <div
+        style={{
+          display: 'flex',
+          flexWrap: 'wrap',
+          gap: '1rem',
+          justifyContent: 'space-between',
+          marginBottom: '1.25rem',
+          rowGap: '1rem',
+        }}
+      >
+        <label style={{ display: 'flex', flexDirection: 'column', gap: '0.5rem', fontWeight: 600 }}>
+          Sværhedsgrad
+          <select
+            value={difficulty}
+            onChange={handleDifficultyChange}
+            style={{
+              appearance: 'none',
+              backgroundColor: '#fff',
+              border: '1px solid rgba(79, 70, 229, 0.3)',
+              borderRadius: '0.75rem',
+              fontSize: '1rem',
+              padding: '0.65rem 1rem',
+              maxWidth: '200px',
+            }}
+          >
+            {Object.entries(difficulties).map(([value, config]) => (
+              <option key={value} value={value}>
+                {config.label}
+              </option>
+            ))}
+          </select>
+        </label>
+
+        <div style={{ display: 'flex', gap: '0.75rem', flexWrap: 'wrap' }}>
+          <button
+            type="button"
+            onClick={() => handleNewGame()}
+            style={{
+              background: '#312e81',
+              border: 'none',
+              borderRadius: '999px',
+              color: '#fff',
+              cursor: 'pointer',
+              fontWeight: 600,
+              padding: '0.65rem 1.5rem',
+            }}
+          >
+            Nyt spil
+          </button>
+          <button
+            type="button"
+            onClick={handleUndo}
+            disabled={!lastMismatch || isLocked || isComplete || selectedCards.length > 0}
+            style={{
+              background: '#64748b',
+              border: 'none',
+              borderRadius: '999px',
+              color: '#fff',
+              cursor: !lastMismatch || isLocked || isComplete || selectedCards.length > 0 ? 'not-allowed' : 'pointer',
+              fontWeight: 600,
+              opacity:
+                !lastMismatch || isLocked || isComplete || selectedCards.length > 0 ? 0.5 : 1,
+              padding: '0.65rem 1.5rem',
+              transition: 'opacity 0.2s ease',
+            }}
+          >
+            Fortryd sidste træk
+          </button>
+        </div>
+      </div>
+
+      <div
+        style={{
+          display: 'flex',
+          flexWrap: 'wrap',
+          gap: '1.5rem',
+          marginBottom: '1.25rem',
+          fontSize: '1.05rem',
+        }}
+      >
+        <div>
+          <strong style={{ display: 'block', marginBottom: '0.35rem' }}>Træk</strong>
+          {moves}
+        </div>
+        <div>
+          <strong style={{ display: 'block', marginBottom: '0.35rem' }}>Tid</strong>
+          {formatSeconds(elapsedMs)} s
+        </div>
+        <div>
+          <strong style={{ display: 'block', marginBottom: '0.35rem' }}>Highscore</strong>
+          {currentHighscore.bestMoves !== null && currentHighscore.bestTimeMs !== null ? (
+            <span>
+              {currentHighscore.bestMoves} træk · {formatSeconds(currentHighscore.bestTimeMs)} s
+            </span>
+          ) : (
+            <span>–</span>
+          )}
+        </div>
+      </div>
+
+      {isComplete && (
+        <div
+          style={{
+            background: 'rgba(34, 197, 94, 0.15)',
+            borderRadius: '1rem',
+            color: '#047857',
+            marginBottom: '1.25rem',
+            padding: '1rem 1.25rem',
+          }}
+        >
+          <strong style={{ display: 'block', marginBottom: '0.35rem' }}>Godt klaret!</strong>
+          Du fandt alle par på {moves} træk og {formatSeconds(elapsedMs)} sekunder.
+        </div>
+      )}
+
+      <div
+        style={{
+          display: 'grid',
+          gap: '0.75rem',
+          gridTemplateColumns,
+          justifyItems: 'stretch',
+          margin: '0 auto',
+          maxWidth: 'min(640px, 100%)',
+        }}
+      >
+        {cards.map((card) => {
+          const isShowing = card.revealed || card.matched
+          const ariaLabel = card.matched
+            ? `Kort, matchet, ${card.symbol}`
+            : card.revealed
+              ? `Kort, vist, ${card.symbol}`
+              : 'Kort, skjult'
+
+          return (
+            <button
+              key={card.id}
+              type="button"
+              onClick={() => handleCardClick(card.id)}
+              disabled={card.matched || card.revealed || isLocked}
+              aria-label={ariaLabel}
+              style={{
+                alignItems: 'center',
+                aspectRatio: '1 / 1',
+                background: isShowing ? '#4f46e5' : 'rgba(79, 70, 229, 0.12)',
+                border: '1px solid rgba(79, 70, 229, 0.3)',
+                borderRadius: '0.9rem',
+                color: isShowing ? '#fff' : '#312e81',
+                cursor: card.matched || card.revealed || isLocked ? 'not-allowed' : 'pointer',
+                display: 'flex',
+                fontSize: 'clamp(1.4rem, 4vw, 2.2rem)',
+                fontWeight: 600,
+                justifyContent: 'center',
+                minHeight: '64px',
+                minWidth: '44px',
+                outlineOffset: 4,
+                transition: 'transform 0.2s ease, background 0.2s ease, color 0.2s ease',
+              }}
+            >
+              <span aria-hidden="true">{isShowing ? card.symbol : '❓'}</span>
+            </button>
+          )
+        })}
+      </div>
+    </section>
+  )
+}

--- a/src/screens/ReactionTestScreen.tsx
+++ b/src/screens/ReactionTestScreen.tsx
@@ -1,0 +1,8 @@
+import { useNavigate } from 'react-router-dom'
+import ReactionTest from '../ReactionTest'
+
+export default function ReactionTestScreen() {
+  const navigate = useNavigate()
+
+  return <ReactionTest onExit={() => navigate('/')} />
+}

--- a/src/utils/memoryHighscores.ts
+++ b/src/utils/memoryHighscores.ts
@@ -1,0 +1,77 @@
+export type MemoryDifficulty = 'easy' | 'medium' | 'hard'
+
+export interface MemoryHighscoreEntry {
+  bestMoves: number | null
+  bestTimeMs: number | null
+}
+
+export type MemoryHighscores = Record<MemoryDifficulty, MemoryHighscoreEntry>
+
+const defaultEntry: MemoryHighscoreEntry = { bestMoves: null, bestTimeMs: null }
+
+export const defaultHighscores: MemoryHighscores = {
+  easy: { ...defaultEntry },
+  medium: { ...defaultEntry },
+  hard: { ...defaultEntry },
+}
+
+function cloneDefaultHighscores(): MemoryHighscores {
+  return {
+    easy: { ...defaultEntry },
+    medium: { ...defaultEntry },
+    hard: { ...defaultEntry },
+  }
+}
+
+export function loadHighscores(): MemoryHighscores {
+  if (typeof window === 'undefined') {
+    return cloneDefaultHighscores()
+  }
+
+  try {
+    const stored = window.localStorage.getItem('memoryHighscores')
+    if (!stored) {
+      return cloneDefaultHighscores()
+    }
+
+    const parsed = JSON.parse(stored) as unknown
+    const result = cloneDefaultHighscores()
+
+    if (parsed && typeof parsed === 'object') {
+      for (const difficulty of Object.keys(result) as MemoryDifficulty[]) {
+        const entry = (parsed as Record<string, unknown>)[difficulty]
+        if (entry && typeof entry === 'object') {
+          const bestMoves = (entry as Record<string, unknown>).bestMoves
+          const bestTimeMs = (entry as Record<string, unknown>).bestTimeMs
+          result[difficulty] = {
+            bestMoves:
+              typeof bestMoves === 'number' && Number.isFinite(bestMoves)
+                ? bestMoves
+                : null,
+            bestTimeMs:
+              typeof bestTimeMs === 'number' && Number.isFinite(bestTimeMs)
+                ? bestTimeMs
+                : null,
+          }
+        }
+      }
+    }
+
+    return result
+  } catch (error) {
+    console.warn('Kunne ikke indlæse memory-highscores, bruger defaults.', error)
+    return cloneDefaultHighscores()
+  }
+}
+
+export function saveHighscores(highscores: MemoryHighscores) {
+  if (typeof window === 'undefined') {
+    return
+  }
+
+  try {
+    window.localStorage.setItem('memoryHighscores', JSON.stringify(highscores))
+  } catch (error) {
+    console.warn('Kunne ikke gemme memory-highscores.', error)
+  }
+}


### PR DESCRIPTION
Tilføjer Memory-spil (4x4, 5x4, 6x4), træk- og tidstæller, localStorage-highscores per sværhedsgrad, keyboard-tilgængelighed, simpel styling og opdateret Home/README. Inkluderer defensiv håndtering af storage og input-lås ved mismatch.

------
https://chatgpt.com/codex/tasks/task_e_68e916e15a74832f92b79be5be8ff9a2