### PR TITLE
Add branded logo to Fokus landing and game screens

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -12,6 +12,35 @@
   color: #0f172a;
 }
 
+.brand-logo {
+  align-items: center;
+  display: inline-flex;
+  gap: clamp(0.5rem, 1.8vw, 0.9rem);
+  text-decoration: none;
+  color: inherit;
+}
+
+.brand-logo--center {
+  justify-content: center;
+}
+
+.brand-logo--left {
+  justify-content: flex-start;
+}
+
+.brand-logo__mark {
+  width: var(--logo-size, 64px);
+  height: var(--logo-size, 64px);
+  flex-shrink: 0;
+  filter: drop-shadow(0 8px 16px rgba(37, 99, 235, 0.25));
+}
+
+.brand-logo__wordmark {
+  font-size: var(--wordmark-size, 1.5rem);
+  font-weight: 700;
+  letter-spacing: -0.02em;
+}
+
 .menu {
   width: min(960px, 100%);
   background-color: rgba(255, 255, 255, 0.85);
@@ -24,6 +53,42 @@
 .menu__header {
   text-align: center;
   margin-bottom: clamp(1.5rem, 4vw, 2.5rem);
+}
+
+.menu__top-bar {
+  align-items: center;
+  display: flex;
+  justify-content: space-between;
+  gap: clamp(0.75rem, 3vw, 1.5rem);
+  margin-bottom: clamp(1.25rem, 3vw, 1.75rem);
+}
+
+.menu__back-button {
+  background: linear-gradient(135deg, rgba(15, 23, 42, 0.85), rgba(30, 64, 175, 0.85));
+  border: 1px solid rgba(255, 255, 255, 0.4);
+  border-radius: 999px;
+  color: #fff;
+  cursor: pointer;
+  font-family: inherit;
+  font-size: 0.9rem;
+  font-weight: 600;
+  padding: 0.6rem 1.5rem;
+  transition: background-color 0.2s ease, border-color 0.2s ease, transform 0.2s ease;
+  backdrop-filter: blur(4px);
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+}
+
+.menu__back-button:hover {
+  background: linear-gradient(135deg, rgba(30, 41, 59, 0.95), rgba(37, 99, 235, 0.95));
+  border-color: rgba(255, 255, 255, 0.6);
+  transform: translateY(-1px);
+}
+
+.menu__back-button:focus-visible {
+  outline: 3px solid rgba(99, 102, 241, 0.45);
+  outline-offset: 3px;
 }
 
 .menu__header h1 {
@@ -102,9 +167,23 @@
     color: #e2e8f0;
   }
 
+  .brand-logo__mark {
+    filter: drop-shadow(0 8px 18px rgba(96, 165, 250, 0.35));
+  }
+
   .menu {
     background-color: rgba(15, 23, 42, 0.75);
     box-shadow: 0 24px 60px rgba(2, 6, 23, 0.55);
+  }
+
+  .menu__back-button {
+    background: linear-gradient(135deg, rgba(30, 41, 59, 0.85), rgba(59, 130, 246, 0.85));
+    border-color: rgba(148, 163, 184, 0.35);
+  }
+
+  .menu__back-button:hover {
+    background: linear-gradient(135deg, rgba(30, 41, 59, 0.95), rgba(96, 165, 250, 0.95));
+    border-color: rgba(226, 232, 240, 0.6);
   }
 
   .menu__card {

--- a/src/ReactionTest.tsx
+++ b/src/ReactionTest.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef, useState } from 'react'
+import BrandLogo from './components/BrandLogo'
 
 type Phase = 'waiting' | 'ready' | 'now' | 'result'
 
@@ -129,33 +130,44 @@ export default function ReactionTest({ onExit }: ReactionTestProps) {
       {textByPhase(phase, reactionTime)}
       <div
         style={{
-          backgroundColor: 'rgba(0, 0, 0, 0.4)',
-          borderRadius: '0.75rem',
-          fontSize: '1rem',
-          left: '1rem',
-          lineHeight: 1.6,
-          padding: '1rem 1.25rem',
-          pointerEvents: 'none',
           position: 'absolute',
-          textAlign: 'left',
+          left: '1rem',
           top: '1rem',
-          width: 'min(240px, calc(100% - 2rem))',
+          display: 'flex',
+          flexDirection: 'column',
+          gap: '0.75rem',
+          alignItems: 'flex-start',
+          maxWidth: 'min(280px, calc(100% - 2rem))',
+          pointerEvents: 'none',
         }}
       >
-        <h2 style={{ fontSize: '1.1rem', margin: '0 0 0.5rem' }}>
-          Top 5 hurtigste tider
-        </h2>
-        {highScores.length === 0 ? (
-          <p style={{ fontSize: '0.95rem', margin: 0 }}>Ingen tider registreret endnu.</p>
-        ) : (
-          <ol style={{ margin: 0, paddingLeft: '1.25rem' }}>
-            {highScores.map((score, index) => (
-              <li key={`${score}-${index}`} style={{ marginBottom: '0.25rem' }}>
-                {Math.round(score)} ms
-              </li>
-            ))}
-          </ol>
-        )}
+        <BrandLogo size={56} wordmarkSize="1.6rem" />
+        <div
+          style={{
+            backgroundColor: 'rgba(0, 0, 0, 0.45)',
+            borderRadius: '0.75rem',
+            fontSize: '1rem',
+            lineHeight: 1.6,
+            padding: '1rem 1.25rem',
+            textAlign: 'left',
+            width: '100%',
+          }}
+        >
+          <h2 style={{ fontSize: '1.1rem', margin: '0 0 0.5rem' }}>
+            Top 5 hurtigste tider
+          </h2>
+          {highScores.length === 0 ? (
+            <p style={{ fontSize: '0.95rem', margin: 0 }}>Ingen tider registreret endnu.</p>
+          ) : (
+            <ol style={{ margin: 0, paddingLeft: '1.25rem' }}>
+              {highScores.map((score, index) => (
+                <li key={`${score}-${index}`} style={{ marginBottom: '0.25rem' }}>
+                  {Math.round(score)} ms
+                </li>
+              ))}
+            </ol>
+          )}
+        </div>
       </div>
       {onExit && (
         <button
@@ -163,21 +175,8 @@ export default function ReactionTest({ onExit }: ReactionTestProps) {
             event.stopPropagation()
             onExit()
           }}
-          style={{
-            backgroundColor: 'rgba(0, 0, 0, 0.45)',
-            border: '1px solid rgba(255, 255, 255, 0.4)',
-            borderRadius: '999px',
-            color: '#fff',
-            cursor: 'pointer',
-            fontFamily: 'inherit',
-            fontSize: '0.9rem',
-            fontWeight: 600,
-            padding: '0.5rem 1.25rem',
-            position: 'absolute',
-            right: '1rem',
-            top: '1rem',
-            transition: 'background-color 0.2s ease, border-color 0.2s ease',
-          }}
+          className="menu__back-button reaction-test__back-button"
+          style={{ right: '1rem', top: '1rem', position: 'absolute' }}
           onMouseDown={(event) => event.stopPropagation()}
           onTouchStart={(event) => event.stopPropagation()}
           onKeyDown={(event) => {

--- a/src/assets/brand-logo.svg
+++ b/src/assets/brand-logo.svg
@@ -1,0 +1,41 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128" role="img" aria-labelledby="title">
+  <title>Fokus logo</title>
+  <path
+    d="M64 10c-18 0-32 14-32 32v5.5c-8.4 5-14 14.5-14 25 0 16.6 13.4 30 30 30h4v5c0 11.6 9.4 21 21 21s21-9.4 21-21v-5h4c16.6 0 30-13.4 30-30 0-10.5-5.6-20-14-25V42C96 24 82 10 64 10z"
+    fill="#3b82f6"
+    stroke="#0f172a"
+    stroke-width="6"
+    stroke-linecap="round"
+    stroke-linejoin="round"
+  />
+  <path
+    d="M48 26c-8.8 0-16 7.2-16 16v4.5M80 26c8.8 0 16 7.2 16 16v4.5"
+    fill="none"
+    stroke="#0f172a"
+    stroke-width="6"
+    stroke-linecap="round"
+  />
+  <path
+    d="M40 68c0-7 5.2-12 12-12 7 0 12 5 12 12v34"
+    fill="none"
+    stroke="#0f172a"
+    stroke-width="6"
+    stroke-linecap="round"
+    stroke-linejoin="round"
+  />
+  <path
+    d="M88 68c0-7-5.2-12-12-12-7 0-12 5-12 12v34"
+    fill="none"
+    stroke="#0f172a"
+    stroke-width="6"
+    stroke-linecap="round"
+    stroke-linejoin="round"
+  />
+  <path
+    d="M24 72h12M92 72h12"
+    fill="none"
+    stroke="#0f172a"
+    stroke-width="6"
+    stroke-linecap="round"
+  />
+</svg>

--- a/src/components/BrandLogo.tsx
+++ b/src/components/BrandLogo.tsx
@@ -1,0 +1,47 @@
+import type { CSSProperties } from 'react'
+import logoUrl from '../assets/brand-logo.svg'
+
+type BrandLogoElement = 'div' | 'span' | 'h1' | 'header'
+
+type BrandLogoProps = {
+  as?: BrandLogoElement
+  align?: 'left' | 'center'
+  size?: number
+  wordmarkSize?: string
+  showWordmark?: boolean
+  className?: string
+  style?: CSSProperties
+}
+
+export default function BrandLogo({
+  as = 'div',
+  align = 'left',
+  size = 64,
+  wordmarkSize = '1.5rem',
+  showWordmark = true,
+  className = '',
+  style,
+}: BrandLogoProps) {
+  const Component = as as keyof JSX.IntrinsicElements
+
+  const inlineStyle = {
+    ...(style ?? {}),
+    '--logo-size': `${size}px`,
+    '--wordmark-size': wordmarkSize,
+  } as CSSProperties
+
+  const classes = [
+    'brand-logo',
+    align === 'center' ? 'brand-logo--center' : 'brand-logo--left',
+    className,
+  ]
+    .filter(Boolean)
+    .join(' ')
+
+  return (
+    <Component className={classes} style={inlineStyle}>
+      <img src={logoUrl} alt="Fokus" className="brand-logo__mark" />
+      {showWordmark ? <span className="brand-logo__wordmark">Fokus</span> : null}
+    </Component>
+  )
+}

--- a/src/screens/Home.tsx
+++ b/src/screens/Home.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react'
 import { Link } from 'react-router-dom'
 import { loadHighscores, type MemoryHighscores } from '../utils/memoryHighscores'
+import BrandLogo from '../components/BrandLogo'
 
 interface GameDefinition {
   id: string
@@ -55,7 +56,13 @@ export default function Home() {
   return (
     <div className="menu">
       <header className="menu__header">
-        <h1>Fokus</h1>
+        <BrandLogo
+          as="h1"
+          align="center"
+          size={96}
+          wordmarkSize="clamp(2.4rem, 6vw, 3.4rem)"
+          style={{ marginBottom: '0.5rem' }}
+        />
         <p>Vælg et spil for at komme i gang.</p>
       </header>
 

--- a/src/screens/MemoryGame.tsx
+++ b/src/screens/MemoryGame.tsx
@@ -6,6 +6,7 @@ import {
   type MemoryDifficulty,
   type MemoryHighscores,
 } from '../utils/memoryHighscores'
+import BrandLogo from '../components/BrandLogo'
 
 interface MemoryCard {
   id: number
@@ -317,34 +318,13 @@ export default function MemoryGame() {
   }
 
   return (
-    <section
-      className="menu"
-      style={{
-        position: 'relative',
-        width: 'min(960px, 100%)',
-      }}
-    >
-      <button
-        type="button"
-        onClick={() => navigate('/')}
-        style={{
-          backgroundColor: 'rgba(0, 0, 0, 0.45)',
-          border: '1px solid rgba(255, 255, 255, 0.4)',
-          borderRadius: '999px',
-          color: '#fff',
-          cursor: 'pointer',
-          fontFamily: 'inherit',
-          fontSize: '0.9rem',
-          fontWeight: 600,
-          padding: '0.5rem 1.25rem',
-          position: 'absolute',
-          right: '1rem',
-          top: '1rem',
-          transition: 'background-color 0.2s ease, border-color 0.2s ease',
-        }}
-      >
-        Tilbage til menu
-      </button>
+    <section className="menu" style={{ width: 'min(960px, 100%)' }}>
+      <div className="menu__top-bar">
+        <BrandLogo size={64} wordmarkSize="1.75rem" />
+        <button type="button" className="menu__back-button" onClick={() => navigate('/')}>
+          Tilbage til menu
+        </button>
+      </div>
       <header className="menu__header" style={{ marginBottom: '1.25rem' }}>
         <h1>Memory</h1>
         <p>Vend kortene og find alle par hurtigst muligt.</p>


### PR DESCRIPTION
## Summary
- add reusable `BrandLogo` component and SVG asset for the Fokus brain mark
- showcase the logo on the home menu and memory screen with a shared top bar and restyled back button
- surface the brand inside the reaction test overlay while keeping the score card layout tidy

## Testing
- `npm run build` *(fails: TypeScript project configuration in repository is incomplete for build mode)*
- `npx tsc -b` *(fails: TypeScript project configuration lacks modern lib definitions and synthetic default imports)*

------
https://chatgpt.com/codex/tasks/task_e_68e96d377934832f850e37f9237a64dc