### PR TITLE
Add sorting mini-game

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,6 +3,7 @@ import './App.css'
 import Home from './screens/Home'
 import MemoryGame from './screens/MemoryGame'
 import ReactionTestScreen from './screens/ReactionTestScreen'
+import SortingGameScreen from './screens/SortingGameScreen'
 
 function AppLayout() {
   return (
@@ -18,6 +19,7 @@ function App() {
       <Route element={<AppLayout />}>
         <Route index element={<Home />} />
         <Route path="memory" element={<MemoryGame />} />
+        <Route path="sorting" element={<SortingGameScreen />} />
       </Route>
       <Route path="reaction-test" element={<ReactionTestScreen />} />
       <Route path="*" element={<Navigate to="/" replace />} />

--- a/src/games/sorting/SortingGame.css
+++ b/src/games/sorting/SortingGame.css
@@ -1,0 +1,402 @@
+.sorting-game {
+  position: relative;
+  width: min(960px, 100%);
+  padding-bottom: 2.5rem;
+}
+
+.sorting-game__header {
+  margin-bottom: clamp(1.5rem, 4vw, 2rem);
+}
+
+.sorting-game__header p {
+  color: #475569;
+  font-size: clamp(1rem, 2.3vw, 1.15rem);
+}
+
+.sorting-game__status {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+  gap: 0.75rem;
+  margin-bottom: clamp(1.25rem, 3vw, 1.75rem);
+}
+
+.sorting-game__metric {
+  background: linear-gradient(135deg, rgba(59, 130, 246, 0.12), rgba(99, 102, 241, 0.2));
+  border: 1px solid rgba(99, 102, 241, 0.18);
+  border-radius: 1rem;
+  padding: 0.9rem 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+}
+
+.sorting-game__metric-label {
+  font-size: 0.85rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: #475569;
+}
+
+.sorting-game__metric-value {
+  font-size: clamp(1.35rem, 3vw, 1.8rem);
+  font-weight: 700;
+  color: #1e293b;
+}
+
+.sorting-game__rules {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1rem;
+  margin-bottom: clamp(1.5rem, 4vw, 2rem);
+}
+
+.sorting-game__rule-column {
+  background: rgba(248, 250, 255, 0.85);
+  border: 1px solid rgba(148, 163, 184, 0.22);
+  border-radius: 1.25rem;
+  padding: 1rem 1.1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.sorting-game__rule-column--left {
+  border-left: 4px solid rgba(59, 130, 246, 0.55);
+}
+
+.sorting-game__rule-column--right {
+  border-right: 4px solid rgba(99, 102, 241, 0.55);
+}
+
+.sorting-game__rule-title {
+  font-weight: 700;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  font-size: 0.85rem;
+  color: #1f2937;
+}
+
+.sorting-game__rule-items {
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+}
+
+.sorting-game__rule-item {
+  align-items: center;
+  display: flex;
+  gap: 0.6rem;
+  font-size: 1rem;
+  color: #334155;
+}
+
+.sorting-game__rule-icon {
+  font-size: 1.4rem;
+  width: 2rem;
+  text-align: center;
+}
+
+.sorting-game__queue {
+  background: linear-gradient(135deg, rgba(79, 70, 229, 0.08), rgba(129, 140, 248, 0.12));
+  border: 1px solid rgba(99, 102, 241, 0.18);
+  border-radius: 1.75rem;
+  padding: clamp(1.5rem, 4vw, 2rem);
+  display: grid;
+  gap: 1.25rem;
+  place-items: center;
+  margin-bottom: clamp(1.5rem, 4vw, 2rem);
+  position: relative;
+  overflow: hidden;
+}
+
+.sorting-game__queue::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(circle at top, rgba(255, 255, 255, 0.22), transparent 65%);
+  pointer-events: none;
+}
+
+.sorting-game__queue--normal {
+  --queue-speed: 0.9s;
+}
+
+.sorting-game__queue--fast {
+  --queue-speed: 0.45s;
+}
+
+.sorting-game__shape {
+  width: clamp(84px, 18vw, 140px);
+  height: clamp(84px, 18vw, 140px);
+  background: var(--shape-color, #4f46e5);
+  border-radius: 1.5rem;
+  transition: transform 0.25s ease, box-shadow 0.25s ease, filter 0.25s ease;
+  box-shadow: 0 18px 35px rgba(79, 70, 229, 0.25);
+  position: relative;
+}
+
+.sorting-game__shape--circle {
+  border-radius: 50%;
+}
+
+.sorting-game__shape--triangle {
+  border-radius: 0;
+  clip-path: polygon(50% 0%, 0% 100%, 100% 100%);
+}
+
+.sorting-game__shape--active {
+  transform: scale(1.12);
+  animation: sorting-game-pulse var(--queue-speed) ease-in-out infinite alternate;
+}
+
+.sorting-game__shape--placeholder {
+  background: rgba(226, 232, 240, 0.65);
+  border: 2px dashed rgba(148, 163, 184, 0.65);
+  box-shadow: none;
+}
+
+.sorting-game__upcoming {
+  display: flex;
+  gap: clamp(0.75rem, 2vw, 1.25rem);
+  justify-content: center;
+  width: 100%;
+}
+
+.sorting-game__upcoming .sorting-game__shape {
+  width: clamp(60px, 12vw, 96px);
+  height: clamp(60px, 12vw, 96px);
+  opacity: 0.7;
+  filter: saturate(0.9);
+  animation: sorting-game-slide var(--queue-speed) linear infinite;
+}
+
+.sorting-game__shape--correct {
+  animation: sorting-game-correct 0.3s ease, sorting-game-pulse var(--queue-speed) ease-in-out infinite alternate;
+  box-shadow: 0 22px 40px rgba(34, 197, 94, 0.35);
+}
+
+.sorting-game__shape--incorrect {
+  animation: sorting-game-shake 0.35s ease;
+  box-shadow: 0 20px 38px rgba(248, 113, 113, 0.35);
+}
+
+.sorting-game__controls {
+  display: flex;
+  gap: 1rem;
+  justify-content: center;
+  margin-bottom: 1.25rem;
+  flex-wrap: wrap;
+}
+
+.sorting-game__control-button {
+  align-items: center;
+  background: linear-gradient(135deg, #4338ca, #6366f1);
+  border: none;
+  border-radius: 999px;
+  color: #fff;
+  cursor: pointer;
+  display: inline-flex;
+  font-size: 1.05rem;
+  font-weight: 600;
+  gap: 0.5rem;
+  padding: 0.85rem 1.9rem;
+  box-shadow: 0 18px 35px rgba(79, 70, 229, 0.22);
+  transition: transform 0.2s ease, box-shadow 0.2s ease, filter 0.2s ease;
+}
+
+.sorting-game__control-button:disabled {
+  cursor: not-allowed;
+  opacity: 0.5;
+  box-shadow: none;
+  transform: none;
+}
+
+.sorting-game__control-button:not(:disabled):hover,
+.sorting-game__control-button:not(:disabled):focus-visible {
+  transform: translateY(-2px);
+  box-shadow: 0 22px 45px rgba(79, 70, 229, 0.32);
+  outline: none;
+}
+
+.sorting-game__actions {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  align-items: center;
+}
+
+.sorting-game__primary-button {
+  background: linear-gradient(135deg, #1d4ed8, #3b82f6);
+  border: none;
+  border-radius: 999px;
+  color: #fff;
+  cursor: pointer;
+  font-size: 1rem;
+  font-weight: 700;
+  padding: 0.85rem 2.2rem;
+  box-shadow: 0 18px 36px rgba(37, 99, 235, 0.25);
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.sorting-game__primary-button:hover,
+.sorting-game__primary-button:focus-visible {
+  transform: translateY(-2px);
+  box-shadow: 0 22px 46px rgba(37, 99, 235, 0.35);
+  outline: none;
+}
+
+.sorting-game__summary {
+  font-size: 1.1rem;
+  font-weight: 600;
+  color: #1e293b;
+  text-align: center;
+}
+
+.sorting-game__overlay {
+  position: absolute;
+  inset: 0;
+  background: rgba(15, 23, 42, 0.58);
+  display: grid;
+  place-items: center;
+  text-align: center;
+  padding: 2rem;
+  border-radius: 1.5rem;
+  color: #f8fafc;
+  backdrop-filter: blur(4px);
+}
+
+.sorting-game__overlay--transparent {
+  background: rgba(15, 23, 42, 0.25);
+  pointer-events: none;
+}
+
+.sorting-game__overlay-content {
+  max-width: 420px;
+  display: grid;
+  gap: 0.75rem;
+}
+
+.sorting-game__overlay-content h2 {
+  font-size: clamp(1.6rem, 4vw, 2rem);
+  margin: 0;
+}
+
+.sorting-game__overlay-content p {
+  margin: 0;
+  line-height: 1.6;
+  font-size: 1rem;
+}
+
+@keyframes sorting-game-pulse {
+  from {
+    transform: scale(1.06);
+  }
+  to {
+    transform: scale(1.12);
+  }
+}
+
+@keyframes sorting-game-slide {
+  from {
+    transform: translateX(0px);
+    opacity: 0.75;
+  }
+  to {
+    transform: translateX(6px);
+    opacity: 0.95;
+  }
+}
+
+@keyframes sorting-game-correct {
+  0% {
+    transform: scale(1);
+  }
+  35% {
+    transform: scale(1.18);
+  }
+  100% {
+    transform: scale(1.1);
+  }
+}
+
+@keyframes sorting-game-shake {
+  0% {
+    transform: translateX(0px);
+  }
+  25% {
+    transform: translateX(-12px);
+  }
+  50% {
+    transform: translateX(12px);
+  }
+  75% {
+    transform: translateX(-8px);
+  }
+  100% {
+    transform: translateX(0px);
+  }
+}
+
+@media (max-width: 640px) {
+  .sorting-game {
+    padding-bottom: 2rem;
+  }
+
+  .sorting-game__rule-column {
+    padding: 0.85rem 0.9rem;
+  }
+
+  .sorting-game__control-button {
+    width: 100%;
+    justify-content: center;
+  }
+}
+
+@media (prefers-color-scheme: dark) {
+  .sorting-game__header p {
+    color: #cbd5f5;
+  }
+
+  .sorting-game__metric {
+    background: linear-gradient(135deg, rgba(79, 70, 229, 0.28), rgba(96, 165, 250, 0.24));
+    border-color: rgba(129, 140, 248, 0.35);
+  }
+
+  .sorting-game__metric-label {
+    color: #cbd5f5;
+  }
+
+  .sorting-game__metric-value {
+    color: #e2e8f0;
+  }
+
+  .sorting-game__rule-column {
+    background: rgba(30, 41, 59, 0.85);
+    border-color: rgba(148, 163, 184, 0.28);
+  }
+
+  .sorting-game__rule-title {
+    color: #e2e8f0;
+  }
+
+  .sorting-game__rule-item {
+    color: #e0e7ff;
+  }
+
+  .sorting-game__queue {
+    background: linear-gradient(135deg, rgba(30, 64, 175, 0.28), rgba(67, 56, 202, 0.3));
+    border-color: rgba(99, 102, 241, 0.32);
+  }
+
+  .sorting-game__control-button {
+    box-shadow: 0 18px 38px rgba(79, 70, 229, 0.38);
+  }
+
+  .sorting-game__primary-button {
+    box-shadow: 0 20px 40px rgba(37, 99, 235, 0.35);
+  }
+
+  .sorting-game__summary {
+    color: #e2e8f0;
+  }
+}

--- a/src/games/sorting/SortingGame.tsx
+++ b/src/games/sorting/SortingGame.tsx
@@ -1,0 +1,505 @@
+import { useCallback, useEffect, useMemo, useRef, useState, type CSSProperties } from 'react'
+import BrandLogo from '../../components/BrandLogo'
+import './SortingGame.css'
+
+type ShapeType = 'square' | 'triangle' | 'circle'
+type Direction = 'left' | 'right'
+
+type Phase = 'idle' | 'running' | 'paused' | 'finished'
+
+interface Shape {
+  id: number
+  type: ShapeType
+  color: string
+}
+
+interface SortingRules {
+  square: Direction
+  triangle: Direction
+  circle: Direction
+}
+
+const SHAPE_TYPES: ShapeType[] = ['square', 'triangle', 'circle']
+const SHAPE_COLORS = ['#f97316', '#22d3ee', '#a855f7', '#facc15', '#ef4444', '#10b981'] as const
+
+const GAME_DURATION_SECONDS = 60
+const SPEED_INCREASE_THRESHOLD = 30
+const NORMAL_RESPONSE_WINDOW_MS = 1800
+const FAST_RESPONSE_WINDOW_MS = 1150
+const INITIAL_QUEUE_LENGTH = 5
+const BEST_SCORE_STORAGE_KEY = 'sorting-game-best-score'
+
+function randomItem<T>(items: readonly T[]): T {
+  return items[Math.floor(Math.random() * items.length)]
+}
+
+function generateRules(): SortingRules {
+  const mapping: SortingRules = {
+    square: Math.random() > 0.5 ? 'left' : 'right',
+    triangle: Math.random() > 0.5 ? 'left' : 'right',
+    circle: Math.random() > 0.5 ? 'left' : 'right',
+  }
+
+  const uniqueDirections = new Set<Direction>([
+    mapping.square,
+    mapping.triangle,
+    mapping.circle,
+  ])
+
+  if (uniqueDirections.size === 1) {
+    const remainingDirection = mapping.square === 'left' ? 'right' : 'left'
+    const shapeToFlip = randomItem<ShapeType>(SHAPE_TYPES)
+    mapping[shapeToFlip] = remainingDirection
+  }
+
+  return mapping
+}
+
+function formatTime(seconds: number): string {
+  const safeSeconds = Math.max(0, Math.floor(seconds))
+  const minutes = Math.floor(safeSeconds / 60)
+  const remainder = safeSeconds % 60
+  return `${minutes}:${remainder.toString().padStart(2, '0')}`
+}
+
+function createShape(id: number): Shape {
+  return {
+    id,
+    type: randomItem(SHAPE_TYPES),
+    color: randomItem(SHAPE_COLORS),
+  }
+}
+
+interface SortingGameProps {
+  onExit?: () => void
+}
+
+export default function SortingGame({ onExit }: SortingGameProps) {
+  const [phase, setPhase] = useState<Phase>('idle')
+  const [queue, setQueue] = useState<Shape[]>(() =>
+    Array.from({ length: INITIAL_QUEUE_LENGTH }, (_, index) => createShape(index)),
+  )
+  const [rules, setRules] = useState<SortingRules>(() => generateRules())
+  const [score, setScore] = useState(0)
+  const [bestScore, setBestScore] = useState(() => {
+    if (typeof window === 'undefined') {
+      return 0
+    }
+
+    const storedValue = window.localStorage.getItem(BEST_SCORE_STORAGE_KEY)
+    return storedValue ? Number.parseInt(storedValue, 10) || 0 : 0
+  })
+  const [timeRemaining, setTimeRemaining] = useState(GAME_DURATION_SECONDS)
+  const [feedback, setFeedback] = useState<'correct' | 'incorrect' | null>(null)
+  const [speedLevel, setSpeedLevel] = useState<'normal' | 'fast'>('normal')
+
+  const shapeIdRef = useRef(queue.length)
+  const scoreRef = useRef(score)
+  const phaseRef = useRef<Phase>(phase)
+  const forcedPauseRef = useRef(false)
+  const responseTimeoutRef = useRef<number | null>(null)
+
+  useEffect(() => {
+    scoreRef.current = score
+  }, [score])
+
+  useEffect(() => {
+    phaseRef.current = phase
+  }, [phase])
+
+  const activeShape = queue[0]
+  const upcomingShapes = useMemo(() => queue.slice(1, 5), [queue])
+
+  const updateBestScore = useCallback((finalScore: number) => {
+    setBestScore((previous) => {
+      if (finalScore <= previous) {
+        return previous
+      }
+
+      if (typeof window !== 'undefined') {
+        window.localStorage.setItem(BEST_SCORE_STORAGE_KEY, String(finalScore))
+      }
+
+      return finalScore
+    })
+  }, [])
+
+  const resetQueue = useCallback(() => {
+    shapeIdRef.current = 0
+    setQueue(Array.from({ length: INITIAL_QUEUE_LENGTH }, () => createShape(shapeIdRef.current++)))
+  }, [])
+
+  const finishGame = useCallback(() => {
+    setPhase((currentPhase) => {
+      if (currentPhase === 'finished') {
+        return currentPhase
+      }
+
+      const finalScore = scoreRef.current
+      updateBestScore(finalScore)
+      phaseRef.current = 'finished'
+      return 'finished'
+    })
+  }, [updateBestScore])
+
+  const advanceCurrentShape = useCallback(
+    (direction: Direction | null) => {
+      setQueue((currentQueue) => {
+        if (currentQueue.length === 0) {
+          return currentQueue
+        }
+
+        const [currentShape, ...rest] = currentQueue
+        const expectedDirection = rules[currentShape.type]
+        const isCorrect = direction !== null && direction === expectedDirection
+
+        setScore((previous) => {
+          const nextScore = isCorrect ? previous + 1 : Math.max(0, previous - 1)
+          scoreRef.current = nextScore
+          return nextScore
+        })
+
+        setFeedback(isCorrect ? 'correct' : 'incorrect')
+
+        const nextQueue = [...rest, createShape(shapeIdRef.current++)]
+        return nextQueue
+      })
+    },
+    [rules],
+  )
+
+  const handleChoice = useCallback(
+    (direction: Direction) => {
+      if (phaseRef.current !== 'running') {
+        return
+      }
+
+      if (responseTimeoutRef.current !== null) {
+        window.clearTimeout(responseTimeoutRef.current)
+        responseTimeoutRef.current = null
+      }
+
+      advanceCurrentShape(direction)
+    },
+    [advanceCurrentShape],
+  )
+
+  useEffect(() => {
+    if (phase !== 'running') {
+      return
+    }
+
+    const interval = window.setInterval(() => {
+      setTimeRemaining((previous) => {
+        if (previous <= 1) {
+          window.clearInterval(interval)
+          finishGame()
+          return 0
+        }
+        return previous - 1
+      })
+    }, 1000)
+
+    return () => {
+      window.clearInterval(interval)
+    }
+  }, [phase, finishGame])
+
+  useEffect(() => {
+    if (phase !== 'running') {
+      return
+    }
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (phaseRef.current !== 'running') {
+        return
+      }
+
+      if (event.key === 'ArrowLeft') {
+        event.preventDefault()
+        handleChoice('left')
+      }
+
+      if (event.key === 'ArrowRight') {
+        event.preventDefault()
+        handleChoice('right')
+      }
+    }
+
+    window.addEventListener('keydown', handleKeyDown)
+    return () => {
+      window.removeEventListener('keydown', handleKeyDown)
+    }
+  }, [phase, handleChoice])
+
+  useEffect(() => {
+    if (phase === 'running' && timeRemaining <= SPEED_INCREASE_THRESHOLD) {
+      setSpeedLevel('fast')
+    }
+
+    if (phase === 'idle' || phase === 'finished') {
+      setSpeedLevel('normal')
+    }
+  }, [phase, timeRemaining])
+
+  useEffect(() => {
+    const handleBlur = () => {
+      if (phaseRef.current === 'running') {
+        forcedPauseRef.current = true
+        setPhase('paused')
+      }
+    }
+
+    const handleFocus = () => {
+      if (forcedPauseRef.current && phaseRef.current === 'paused') {
+        forcedPauseRef.current = false
+        setPhase('running')
+      }
+    }
+
+    window.addEventListener('blur', handleBlur)
+    window.addEventListener('focus', handleFocus)
+
+    return () => {
+      window.removeEventListener('blur', handleBlur)
+      window.removeEventListener('focus', handleFocus)
+    }
+  }, [])
+
+  useEffect(() => {
+    if (!feedback) {
+      return
+    }
+
+    const timeout = window.setTimeout(() => {
+      setFeedback(null)
+    }, 250)
+
+    return () => {
+      window.clearTimeout(timeout)
+    }
+  }, [feedback])
+
+  useEffect(() => {
+    if (phase !== 'running') {
+      if (responseTimeoutRef.current !== null) {
+        window.clearTimeout(responseTimeoutRef.current)
+        responseTimeoutRef.current = null
+      }
+      return
+    }
+
+    if (!activeShape) {
+      return
+    }
+
+    if (responseTimeoutRef.current !== null) {
+      window.clearTimeout(responseTimeoutRef.current)
+    }
+
+    const delay = speedLevel === 'fast' ? FAST_RESPONSE_WINDOW_MS : NORMAL_RESPONSE_WINDOW_MS
+
+    responseTimeoutRef.current = window.setTimeout(() => {
+      responseTimeoutRef.current = null
+      advanceCurrentShape(null)
+    }, delay)
+
+    return () => {
+      if (responseTimeoutRef.current !== null) {
+        window.clearTimeout(responseTimeoutRef.current)
+        responseTimeoutRef.current = null
+      }
+    }
+  }, [phase, activeShape, speedLevel, advanceCurrentShape])
+
+
+  const startGame = useCallback(() => {
+    setScore(0)
+    scoreRef.current = 0
+    setTimeRemaining(GAME_DURATION_SECONDS)
+    setRules(generateRules())
+    resetQueue()
+    setFeedback(null)
+    forcedPauseRef.current = false
+    setSpeedLevel('normal')
+    if (responseTimeoutRef.current !== null) {
+      window.clearTimeout(responseTimeoutRef.current)
+      responseTimeoutRef.current = null
+    }
+    setPhase('running')
+  }, [resetQueue])
+
+  const resumeGame = useCallback(() => {
+    if (phaseRef.current === 'paused') {
+      forcedPauseRef.current = false
+      setPhase('running')
+    }
+  }, [])
+
+  const speedClass = useMemo(() => {
+    return speedLevel === 'fast' ? 'sorting-game__queue--fast' : 'sorting-game__queue--normal'
+  }, [speedLevel])
+
+  const leftShapes = useMemo(() => SHAPE_TYPES.filter((shape) => rules[shape] === 'left'), [rules])
+  const rightShapes = useMemo(
+    () => SHAPE_TYPES.filter((shape) => rules[shape] === 'right'),
+    [rules],
+  )
+
+  return (
+    <section className="menu sorting-game">
+      <div className="menu__top-bar">
+        <BrandLogo size={64} wordmarkSize="1.75rem" />
+        <button type="button" className="menu__back-button" onClick={onExit}>
+          Tilbage til menu
+        </button>
+      </div>
+
+      <header className="menu__header sorting-game__header">
+        <h1>Sorteringsspillet</h1>
+        <p>
+          Sortér figurerne efter reglerne ved at bruge piletasterne eller knapperne nedenfor.
+        </p>
+      </header>
+
+      <div className="sorting-game__status">
+        <div className="sorting-game__metric">
+          <span className="sorting-game__metric-label">Score</span>
+          <span className="sorting-game__metric-value">{score}</span>
+        </div>
+        <div className="sorting-game__metric">
+          <span className="sorting-game__metric-label">Bedste</span>
+          <span className="sorting-game__metric-value">{bestScore}</span>
+        </div>
+        <div className="sorting-game__metric">
+          <span className="sorting-game__metric-label">Tid</span>
+          <span className="sorting-game__metric-value">{formatTime(timeRemaining)}</span>
+        </div>
+      </div>
+
+      <div className="sorting-game__rules">
+        <div className="sorting-game__rule-column sorting-game__rule-column--left">
+          <div className="sorting-game__rule-title">Venstre</div>
+          <div className="sorting-game__rule-items">
+            {leftShapes.map((shape) => (
+              <div key={`left-${shape}`} className={`sorting-game__rule-item sorting-game__rule-item--${shape}`}>
+                <span className="sorting-game__rule-icon" aria-hidden="true">
+                  {shape === 'square' && '▢'}
+                  {shape === 'triangle' && '△'}
+                  {shape === 'circle' && '◯'}
+                </span>
+                <span className="sorting-game__rule-label">{shape === 'square' ? 'Firkant' : shape === 'triangle' ? 'Trekant' : 'Cirkel'}</span>
+              </div>
+            ))}
+          </div>
+        </div>
+        <div className="sorting-game__rule-column sorting-game__rule-column--right">
+          <div className="sorting-game__rule-title">Højre</div>
+          <div className="sorting-game__rule-items">
+            {rightShapes.map((shape) => (
+              <div key={`right-${shape}`} className={`sorting-game__rule-item sorting-game__rule-item--${shape}`}>
+                <span className="sorting-game__rule-icon" aria-hidden="true">
+                  {shape === 'square' && '▢'}
+                  {shape === 'triangle' && '△'}
+                  {shape === 'circle' && '◯'}
+                </span>
+                <span className="sorting-game__rule-label">{shape === 'square' ? 'Firkant' : shape === 'triangle' ? 'Trekant' : 'Cirkel'}</span>
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
+
+      <div className={`sorting-game__queue ${speedClass}`}>
+        {activeShape ? (
+          <div
+            key={activeShape.id}
+            className={`sorting-game__shape sorting-game__shape--active sorting-game__shape--${activeShape.type} ${feedback ? `sorting-game__shape--${feedback}` : ''}`}
+            style={{ '--shape-color': activeShape.color } as CSSProperties}
+            aria-live="polite"
+          />
+        ) : (
+          <div className="sorting-game__shape sorting-game__shape--placeholder" />
+        )}
+
+        <div className="sorting-game__upcoming" aria-label="Kommende figurer">
+          {upcomingShapes.map((shape) => (
+            <div
+              key={shape.id}
+              className={`sorting-game__shape sorting-game__shape--${shape.type}`}
+              style={{ '--shape-color': shape.color } as CSSProperties}
+            />
+          ))}
+        </div>
+      </div>
+
+      <div className="sorting-game__controls" aria-hidden={phase !== 'running'}>
+        <button
+          type="button"
+          className="sorting-game__control-button sorting-game__control-button--left"
+          onClick={() => handleChoice('left')}
+          disabled={phase !== 'running'}
+        >
+          ← Venstre
+        </button>
+        <button
+          type="button"
+          className="sorting-game__control-button sorting-game__control-button--right"
+          onClick={() => handleChoice('right')}
+          disabled={phase !== 'running'}
+        >
+          Højre →
+        </button>
+      </div>
+
+      <div className="sorting-game__actions">
+        {phase === 'idle' && (
+          <button type="button" className="sorting-game__primary-button" onClick={startGame}>
+            Start spil
+          </button>
+        )}
+        {phase === 'paused' && (
+          <button type="button" className="sorting-game__primary-button" onClick={resumeGame}>
+            Fortsæt
+          </button>
+        )}
+        {phase === 'finished' && (
+          <>
+            <div className="sorting-game__summary">Din slutscore: {scoreRef.current}</div>
+            <button type="button" className="sorting-game__primary-button" onClick={startGame}>
+              Spil igen
+            </button>
+          </>
+        )}
+      </div>
+
+      {phase === 'paused' && (
+        <div className="sorting-game__overlay" role="status" aria-live="assertive">
+          <div className="sorting-game__overlay-content">
+            <h2>Pause</h2>
+            <p>Vinduet mistede fokus. Klik på "Fortsæt" eller fokusér vinduet for at fortsætte.</p>
+          </div>
+        </div>
+      )}
+
+      {phase === 'idle' && (
+        <div className="sorting-game__overlay sorting-game__overlay--transparent" role="status" aria-live="polite">
+          <div className="sorting-game__overlay-content">
+            <h2>Klar?</h2>
+            <p>Tryk på "Start spil" og brug derefter piletasterne for at sortere figurerne.</p>
+          </div>
+        </div>
+      )}
+
+      {phase === 'finished' && (
+        <div className="sorting-game__overlay" role="status" aria-live="assertive">
+          <div className="sorting-game__overlay-content">
+            <h2>Tiden er gået!</h2>
+            <p>Din score: {scoreRef.current}</p>
+            <p>Bedste score: {bestScore}</p>
+          </div>
+        </div>
+      )}
+    </section>
+  )
+}

--- a/src/screens/Home.tsx
+++ b/src/screens/Home.tsx
@@ -28,6 +28,14 @@ const games: GameDefinition[] = [
     path: '/memory',
     startLabel: 'Start memory',
   },
+  {
+    id: 'sorting',
+    name: 'Sorteringsspillet',
+    description:
+      'Sortér figurerne til venstre eller højre efter reglerne. Brug piletasterne, hold tempoet og jag din bedste score.',
+    path: '/sorting',
+    startLabel: 'Start sorteringsspil',
+  },
 ]
 
 export default function Home() {

--- a/src/screens/SortingGameScreen.tsx
+++ b/src/screens/SortingGameScreen.tsx
@@ -1,0 +1,8 @@
+import { useNavigate } from 'react-router-dom'
+import SortingGame from '../games/sorting/SortingGame'
+
+export default function SortingGameScreen() {
+  const navigate = useNavigate()
+
+  return <SortingGame onExit={() => navigate('/')} />
+}


### PR DESCRIPTION
## Summary
- add the new sorting mini-game with timer, rule mapping, keyboard controls, and localStorage best score tracking
- create a dedicated screen, route, and home card so the game can be launched from the main menu
- design bespoke styling for the sorting interface, including queue visuals, feedback animations, and overlays

## Testing
- npm run test
- npm run build *(fails: TypeScript expects prebuilt declaration outputs for the composite projects and exits with TS6305 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68eccdc6a524832fb374b9de0703dd92