### PR TITLE
Adjust sorting game flow and visuals

### DIFF
--- a/src/games/sorting/SortingGame.css
+++ b/src/games/sorting/SortingGame.css
@@ -90,23 +90,57 @@
   color: #334155;
 }
 
-.sorting-game__rule-icon {
-  font-size: 1.4rem;
-  width: 2rem;
-  text-align: center;
+.sorting-game__rule-shape {
+  width: 2.25rem;
+  height: 2.25rem;
+  background: rgba(79, 70, 229, 0.14);
+  border-radius: 0.75rem;
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.sorting-game__rule-shape::after {
+  content: '';
+  display: block;
+  width: 75%;
+  height: 75%;
+  background: rgba(79, 70, 229, 0.8);
+  border-radius: 1rem;
+}
+
+.sorting-game__rule-item--square .sorting-game__rule-shape::after {
+  background: #f97316;
+}
+
+.sorting-game__rule-item--triangle .sorting-game__rule-shape::after {
+  background: #22d3ee;
+}
+
+.sorting-game__rule-item--circle .sorting-game__rule-shape::after {
+  background: #a855f7;
+}
+
+.sorting-game__rule-shape--circle::after {
+  border-radius: 999px;
+}
+
+.sorting-game__rule-shape--triangle::after {
+  border-radius: 0;
+  clip-path: polygon(50% 0%, 0% 100%, 100% 100%);
 }
 
 .sorting-game__queue {
   background: linear-gradient(135deg, rgba(79, 70, 229, 0.08), rgba(129, 140, 248, 0.12));
   border: 1px solid rgba(99, 102, 241, 0.18);
   border-radius: 1.75rem;
-  padding: clamp(1.5rem, 4vw, 2rem);
-  display: grid;
-  gap: 1.25rem;
-  place-items: center;
+  padding: clamp(1.5rem, 4vw, 2.25rem);
+  display: flex;
+  justify-content: center;
   margin-bottom: clamp(1.5rem, 4vw, 2rem);
   position: relative;
-  overflow: hidden;
+  overflow: visible;
 }
 
 .sorting-game__queue::after {
@@ -117,12 +151,17 @@
   pointer-events: none;
 }
 
-.sorting-game__queue--normal {
-  --queue-speed: 0.9s;
+.sorting-game__queue-track {
+  position: relative;
+  width: min(440px, 100%);
+  height: clamp(120px, 28vw, 210px);
 }
 
-.sorting-game__queue--fast {
-  --queue-speed: 0.45s;
+.sorting-game__queue-track .sorting-game__shape {
+  position: absolute;
+  left: 50%;
+  bottom: 0;
+  transform-origin: center bottom;
 }
 
 .sorting-game__shape {
@@ -130,7 +169,7 @@
   height: clamp(84px, 18vw, 140px);
   background: var(--shape-color, #4f46e5);
   border-radius: 1.5rem;
-  transition: transform 0.25s ease, box-shadow 0.25s ease, filter 0.25s ease;
+  transition: transform 0.3s ease, box-shadow 0.3s ease, filter 0.3s ease, opacity 0.3s ease;
   box-shadow: 0 18px 35px rgba(79, 70, 229, 0.25);
   position: relative;
 }
@@ -145,39 +184,23 @@
 }
 
 .sorting-game__shape--active {
-  transform: scale(1.12);
-  animation: sorting-game-pulse var(--queue-speed) ease-in-out infinite alternate;
+  filter: saturate(1.1);
+  box-shadow: 0 20px 40px rgba(79, 70, 229, 0.32);
 }
 
-.sorting-game__shape--placeholder {
-  background: rgba(226, 232, 240, 0.65);
-  border: 2px dashed rgba(148, 163, 184, 0.65);
-  box-shadow: none;
-}
-
-.sorting-game__upcoming {
-  display: flex;
-  gap: clamp(0.75rem, 2vw, 1.25rem);
-  justify-content: center;
-  width: 100%;
-}
-
-.sorting-game__upcoming .sorting-game__shape {
-  width: clamp(60px, 12vw, 96px);
-  height: clamp(60px, 12vw, 96px);
-  opacity: 0.7;
-  filter: saturate(0.9);
-  animation: sorting-game-slide var(--queue-speed) linear infinite;
+.sorting-game__shape--queued {
+  box-shadow: 0 14px 28px rgba(79, 70, 229, 0.18);
+  filter: saturate(0.85);
 }
 
 .sorting-game__shape--correct {
-  animation: sorting-game-correct 0.3s ease, sorting-game-pulse var(--queue-speed) ease-in-out infinite alternate;
-  box-shadow: 0 22px 40px rgba(34, 197, 94, 0.35);
+  box-shadow: 0 22px 42px rgba(34, 197, 94, 0.38);
+  filter: saturate(1.2) brightness(1.05);
 }
 
 .sorting-game__shape--incorrect {
-  animation: sorting-game-shake 0.35s ease;
-  box-shadow: 0 20px 38px rgba(248, 113, 113, 0.35);
+  box-shadow: 0 20px 38px rgba(248, 113, 113, 0.38);
+  filter: saturate(0.75) brightness(0.95);
 }
 
 .sorting-game__controls {
@@ -265,11 +288,6 @@
   backdrop-filter: blur(4px);
 }
 
-.sorting-game__overlay--transparent {
-  background: rgba(15, 23, 42, 0.25);
-  pointer-events: none;
-}
-
 .sorting-game__overlay-content {
   max-width: 420px;
   display: grid;
@@ -287,55 +305,7 @@
   font-size: 1rem;
 }
 
-@keyframes sorting-game-pulse {
-  from {
-    transform: scale(1.06);
-  }
-  to {
-    transform: scale(1.12);
-  }
-}
-
-@keyframes sorting-game-slide {
-  from {
-    transform: translateX(0px);
-    opacity: 0.75;
-  }
-  to {
-    transform: translateX(6px);
-    opacity: 0.95;
-  }
-}
-
-@keyframes sorting-game-correct {
-  0% {
-    transform: scale(1);
-  }
-  35% {
-    transform: scale(1.18);
-  }
-  100% {
-    transform: scale(1.1);
-  }
-}
-
-@keyframes sorting-game-shake {
-  0% {
-    transform: translateX(0px);
-  }
-  25% {
-    transform: translateX(-12px);
-  }
-  50% {
-    transform: translateX(12px);
-  }
-  75% {
-    transform: translateX(-8px);
-  }
-  100% {
-    transform: translateX(0px);
-  }
-}
+/* Animations removed because queue positioning relies on inline transforms */
 
 @media (max-width: 640px) {
   .sorting-game {


### PR DESCRIPTION
## Summary
- remove the initial overlay so the game starts from the button alone
- require players to choose a direction before advancing shapes and track how many shapes were sorted
- restyle the queue and rule hints so preview figures match the playable shapes

## Testing
- `npm run build` *(fails: TypeScript build expects declaration outputs in src/)*

------
https://chatgpt.com/codex/tasks/task_e_68ecd6387484832fad2fbfec0cf4b538