### PR TITLE
Fix sorting game queue visibility issues

### DIFF
--- a/src/games/sorting/SortingGame.css
+++ b/src/games/sorting/SortingGame.css
@@ -126,6 +126,10 @@
   overflow: visible;
 }
 
+.sorting-game__queue--hidden {
+  pointer-events: none;
+}
+
 .sorting-game__queue::after {
   content: '';
   position: absolute;
@@ -138,6 +142,9 @@
   position: relative;
   width: min(440px, 100%);
   height: clamp(120px, 28vw, 210px);
+  display: flex;
+  align-items: center;
+  justify-content: center;
 }
 
 .sorting-game__queue-track .sorting-game__shape {
@@ -145,6 +152,14 @@
   left: 50%;
   bottom: 0;
   transform-origin: center bottom;
+}
+
+.sorting-game__queue-placeholder {
+  color: #475569;
+  font-size: clamp(0.95rem, 2.3vw, 1.05rem);
+  line-height: 1.5;
+  text-align: center;
+  max-width: 18rem;
 }
 
 .sorting-game__shape {
@@ -262,6 +277,8 @@
   border-radius: 1.5rem;
   color: #f8fafc;
   backdrop-filter: blur(4px);
+  z-index: 10;
+  pointer-events: auto;
 }
 
 .sorting-game__overlay-content {
@@ -421,6 +438,10 @@
   .sorting-game__queue {
     background: linear-gradient(135deg, rgba(30, 64, 175, 0.28), rgba(67, 56, 202, 0.3));
     border-color: rgba(99, 102, 241, 0.32);
+  }
+
+  .sorting-game__queue-placeholder {
+    color: #cbd5f5;
   }
 
   .sorting-game__control-button {

--- a/src/games/sorting/SortingGame.tsx
+++ b/src/games/sorting/SortingGame.tsx
@@ -84,9 +84,7 @@ interface SortingGameProps {
 
 export default function SortingGame({ onExit }: SortingGameProps) {
   const [phase, setPhase] = useState<Phase>('idle')
-  const [queue, setQueue] = useState<Shape[]>(() =>
-    Array.from({ length: INITIAL_QUEUE_LENGTH }, (_, index) => createShape(index)),
-  )
+  const [queue, setQueue] = useState<Shape[]>([])
   const [rules, setRules] = useState<SortingRules>(() => generateRules())
   const [score, setScore] = useState(0)
   const [sortedCount, setSortedCount] = useState(0)
@@ -114,8 +112,6 @@ export default function SortingGame({ onExit }: SortingGameProps) {
   useEffect(() => {
     phaseRef.current = phase
   }, [phase])
-
-  const activeShape = queue[0]
 
   const updateBestScore = useCallback((finalScore: number) => {
     setBestScore((previous) => {
@@ -412,35 +408,45 @@ export default function SortingGame({ onExit }: SortingGameProps) {
           </div>
         </div>
 
-        <div className="sorting-game__queue">
+        <div
+          className={`sorting-game__queue${
+            phase === 'running' || phase === 'paused' ? '' : ' sorting-game__queue--hidden'
+          }`}
+        >
           <div className="sorting-game__queue-track" aria-label="Figurkø">
-            {queue.map((shape, index) => {
-              const isActive = index === 0
-              const offset = Math.min(index, 6)
-              const translateX = offset * 2.6
-              const translateY = offset * 0.35
-              const scale = isActive ? 1 : Math.max(0.7, 1 - offset * 0.08)
-              const opacity = isActive ? 1 : Math.max(0.35, 0.85 - offset * 0.1)
-              const feedbackClass = isActive && feedback ? ` sorting-game__shape--${feedback}` : ''
+            {phase === 'running' || phase === 'paused' ? (
+              queue.map((shape, index) => {
+                const isActive = index === 0
+                const offset = Math.min(index, 4)
+                const translateX = offset * 1.6
+                const translateY = offset * 0.3
+                const scale = isActive ? 1 : Math.max(0.7, 1 - offset * 0.08)
+                const opacity = isActive ? 1 : Math.max(0.35, 0.85 - offset * 0.1)
+                const feedbackClass = isActive && feedback ? ` sorting-game__shape--${feedback}` : ''
 
-              return (
-                <div
-                  key={shape.id}
-                  className={`sorting-game__shape sorting-game__shape--${shape.type}${isActive ? ' sorting-game__shape--active' : ' sorting-game__shape--queued'}${feedbackClass}`}
-                  style={
-                    {
-                      '--shape-color': shape.color,
-                      transform: `translateX(calc(-50% + ${translateX}rem)) translateY(${translateY}rem) scale(${scale})`,
-                      opacity,
-                      zIndex: queue.length - index,
-                    } as CSSProperties
-                  }
-                  aria-label={isActive ? `Aktiv figur: ${SHAPE_LABELS[shape.type]}` : undefined}
-                  aria-hidden={!isActive}
-                  aria-live={isActive ? 'polite' : undefined}
-                />
-              )
-            })}
+                return (
+                  <div
+                    key={shape.id}
+                    className={`sorting-game__shape sorting-game__shape--${shape.type}${isActive ? ' sorting-game__shape--active' : ' sorting-game__shape--queued'}${feedbackClass}`}
+                    style={
+                      {
+                        '--shape-color': shape.color,
+                        transform: `translateX(calc(-50% + ${translateX}rem)) translateY(${translateY}rem) scale(${scale})`,
+                        opacity,
+                        zIndex: queue.length - index,
+                      } as CSSProperties
+                    }
+                    aria-label={isActive ? `Aktiv figur: ${SHAPE_LABELS[shape.type]}` : undefined}
+                    aria-hidden={!isActive}
+                    aria-live={isActive ? 'polite' : undefined}
+                  />
+                )
+              })
+            ) : (
+              <div className="sorting-game__queue-placeholder">
+                Tryk på &quot;Start spil&quot; for at begynde at sortere figurerne.
+              </div>
+            )}
           </div>
         </div>
 


### PR DESCRIPTION
## Summary
- hide the sorting queue until the game starts and add a friendly placeholder
- adjust queue stacking so shapes no longer overlap the hint columns and overlay
- ensure the end-of-game overlay renders above shapes and keep spacing consistent

## Testing
- npm run build *(fails: TypeScript reports TS6305 because referenced declaration outputs are missing in this repo configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68ecf615b5bc832f8b8d7dcdcbf8e7db