### PR TITLE
Adjust sorting game layout and interactions

### DIFF
--- a/src/games/sorting/SortingGame.css
+++ b/src/games/sorting/SortingGame.css
@@ -20,6 +20,14 @@
   margin-bottom: clamp(1.25rem, 3vw, 1.75rem);
 }
 
+.sorting-game__actions--top {
+  margin-bottom: clamp(1.25rem, 4vw, 1.75rem);
+}
+
+.sorting-game__actions--top:empty {
+  display: none;
+}
+
 .sorting-game__metric {
   background: linear-gradient(135deg, rgba(59, 130, 246, 0.12), rgba(99, 102, 241, 0.2));
   border: 1px solid rgba(99, 102, 241, 0.18);
@@ -124,6 +132,8 @@
   margin-bottom: clamp(1.5rem, 4vw, 2rem);
   position: relative;
   overflow: visible;
+  flex: 1 1 360px;
+  max-width: min(100%, 460px);
 }
 
 .sorting-game__queue--hidden {
@@ -140,7 +150,7 @@
 
 .sorting-game__queue-track {
   position: relative;
-  width: min(440px, 100%);
+  width: min(380px, 100%);
   height: clamp(120px, 28vw, 210px);
   display: flex;
   align-items: center;
@@ -155,11 +165,49 @@
 }
 
 .sorting-game__queue-placeholder {
+  align-items: center;
+  appearance: none;
+  background: rgba(248, 250, 255, 0.85);
+  border: 2px dashed rgba(99, 102, 241, 0.35);
+  border-radius: 1.5rem;
+  box-shadow: 0 14px 30px rgba(79, 70, 229, 0.18);
   color: #475569;
+  cursor: pointer;
+  display: inline-flex;
+  font: inherit;
   font-size: clamp(0.95rem, 2.3vw, 1.05rem);
+  font-weight: 600;
+  justify-content: center;
   line-height: 1.5;
+  max-width: min(100%, 22rem);
+  padding: clamp(1.1rem, 3vw, 1.4rem) clamp(1.4rem, 4vw, 2.1rem);
   text-align: center;
-  max-width: 18rem;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease, background 0.2s ease;
+}
+
+.sorting-game__queue-placeholder:hover,
+.sorting-game__queue-placeholder:focus-visible {
+  background: rgba(255, 255, 255, 0.95);
+  border-color: rgba(99, 102, 241, 0.6);
+  box-shadow: 0 18px 36px rgba(79, 70, 229, 0.22);
+  transform: translateY(-2px);
+  outline: none;
+}
+
+.sorting-game__queue-placeholder:focus-visible {
+  box-shadow: 0 0 0 4px rgba(129, 140, 248, 0.35), 0 20px 40px rgba(79, 70, 229, 0.22);
+}
+
+.sorting-game__queue-placeholder:disabled {
+  cursor: default;
+  opacity: 0.75;
+  transform: none;
+}
+
+.sorting-game__queue-placeholder:disabled:hover {
+  background: rgba(248, 250, 255, 0.85);
+  border-color: rgba(99, 102, 241, 0.35);
+  box-shadow: 0 14px 30px rgba(79, 70, 229, 0.18);
 }
 
 .sorting-game__shape {

--- a/src/games/sorting/SortingGame.tsx
+++ b/src/games/sorting/SortingGame.tsx
@@ -372,6 +372,19 @@ export default function SortingGame({ onExit }: SortingGameProps) {
         </p>
       </header>
 
+      <div className="sorting-game__actions sorting-game__actions--top">
+        {phase === 'idle' && (
+          <button type="button" className="sorting-game__primary-button" onClick={startGame}>
+            Start spil
+          </button>
+        )}
+        {phase === 'paused' && (
+          <button type="button" className="sorting-game__primary-button" onClick={resumeGame}>
+            Fortsæt
+          </button>
+        )}
+      </div>
+
       <div className="sorting-game__status">
         <div className="sorting-game__metric">
           <span className="sorting-game__metric-label">Score</span>
@@ -418,8 +431,7 @@ export default function SortingGame({ onExit }: SortingGameProps) {
               queue.map((shape, index) => {
                 const isActive = index === 0
                 const offset = Math.min(index, 4)
-                const translateX = offset * 1.6
-                const translateY = offset * 0.3
+                const translateY = offset * -0.65
                 const scale = isActive ? 1 : Math.max(0.7, 1 - offset * 0.08)
                 const opacity = isActive ? 1 : Math.max(0.35, 0.85 - offset * 0.1)
                 const feedbackClass = isActive && feedback ? ` sorting-game__shape--${feedback}` : ''
@@ -431,7 +443,7 @@ export default function SortingGame({ onExit }: SortingGameProps) {
                     style={
                       {
                         '--shape-color': shape.color,
-                        transform: `translateX(calc(-50% + ${translateX}rem)) translateY(${translateY}rem) scale(${scale})`,
+                        transform: `translate(-50%, ${translateY}rem) scale(${scale})`,
                         opacity,
                         zIndex: queue.length - index,
                       } as CSSProperties
@@ -443,9 +455,14 @@ export default function SortingGame({ onExit }: SortingGameProps) {
                 )
               })
             ) : (
-              <div className="sorting-game__queue-placeholder">
-                Tryk på &quot;Start spil&quot; for at begynde at sortere figurerne.
-              </div>
+              <button
+                type="button"
+                className="sorting-game__queue-placeholder"
+                onClick={phase === 'idle' ? startGame : undefined}
+                disabled={phase !== 'idle'}
+              >
+                Tryk her eller på &quot;Start spil&quot; for at begynde at sortere figurerne.
+              </button>
             )}
           </div>
         </div>
@@ -484,19 +501,6 @@ export default function SortingGame({ onExit }: SortingGameProps) {
         >
           Højre →
         </button>
-      </div>
-
-      <div className="sorting-game__actions">
-        {phase === 'idle' && (
-          <button type="button" className="sorting-game__primary-button" onClick={startGame}>
-            Start spil
-          </button>
-        )}
-        {phase === 'paused' && (
-          <button type="button" className="sorting-game__primary-button" onClick={resumeGame}>
-            Fortsæt
-          </button>
-        )}
       </div>
 
       {phase === 'paused' && (


### PR DESCRIPTION
## Summary
- place the start/resume actions above the status panel so the primary controls are immediately visible
- center the sorting queue presentation and update the stack transforms so shapes no longer overlap the hint columns
- turn the placeholder message into a styled button that can also start the game when it is idle

## Testing
- npm run build *(fails: existing declaration files such as src/App.d.ts trigger TS6305 errors in the current setup)*

------
https://chatgpt.com/codex/tasks/task_e_68ecf9898d8c832f820077addda2917b