### PR TITLE
Improve sorting placeholder accessibility and dark mode contrast

### DIFF
--- a/src/games/sorting/SortingGame.css
+++ b/src/games/sorting/SortingGame.css
@@ -52,31 +52,29 @@
 }
 
 .sorting-game__play-area {
-  display: flex;
-  align-items: stretch;
+  display: grid;
+  grid-template-columns: minmax(200px, 240px) minmax(280px, 1fr) minmax(200px, 240px);
+  align-items: start;
   justify-content: center;
   gap: clamp(1rem, 4vw, 3rem);
   margin-bottom: clamp(1.5rem, 4vw, 2.5rem);
-  flex-wrap: wrap;
 }
 
 .sorting-game__rule-column {
-  background: rgba(248, 250, 255, 0.85);
-  border: 1px solid rgba(148, 163, 184, 0.22);
-  border-radius: 1.25rem;
-  padding: clamp(1rem, 2.8vw, 1.4rem) clamp(1.1rem, 3vw, 1.6rem);
   display: flex;
   flex-direction: column;
   gap: 0.75rem;
-  flex: 0 1 240px;
+  align-self: start;
+  background: none;
+  border: none;
+  padding: 0;
+  max-width: 240px;
+  width: 100%;
 }
 
-.sorting-game__rule-column--left {
-  border-left: 4px solid rgba(59, 130, 246, 0.55);
-}
-
+.sorting-game__rule-column--left,
 .sorting-game__rule-column--right {
-  border-right: 4px solid rgba(99, 102, 241, 0.55);
+  border: none;
 }
 
 .sorting-game__rule-title {
@@ -134,6 +132,8 @@
   overflow: visible;
   flex: 1 1 360px;
   max-width: min(100%, 460px);
+  justify-self: center;
+  width: 100%;
 }
 
 .sorting-game__queue--hidden {
@@ -171,18 +171,20 @@
   border: 2px dashed rgba(99, 102, 241, 0.35);
   border-radius: 1.5rem;
   box-shadow: 0 14px 30px rgba(79, 70, 229, 0.18);
+  box-sizing: border-box;
   color: #475569;
   cursor: pointer;
-  display: inline-flex;
+  display: flex;
   font: inherit;
   font-size: clamp(0.95rem, 2.3vw, 1.05rem);
   font-weight: 600;
   justify-content: center;
   line-height: 1.5;
-  max-width: min(100%, 22rem);
   padding: clamp(1.1rem, 3vw, 1.4rem) clamp(1.4rem, 4vw, 2.1rem);
   text-align: center;
   transition: transform 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease, background 0.2s ease;
+  width: 100%;
+  height: 100%;
 }
 
 .sorting-game__queue-placeholder:hover,
@@ -426,20 +428,21 @@
 
 /* Animations removed because queue positioning relies on inline transforms */
 
-@media (max-width: 640px) {
-  .sorting-game {
-    padding-bottom: 2rem;
-  }
-
+@media (max-width: 900px) {
   .sorting-game__play-area {
-    flex-direction: column;
-    align-items: center;
+    grid-template-columns: minmax(0, 1fr);
+    justify-items: center;
     gap: 1.25rem;
   }
 
   .sorting-game__rule-column {
-    padding: 0.85rem 1rem;
-    width: min(100%, 320px);
+    max-width: 320px;
+  }
+}
+
+@media (max-width: 640px) {
+  .sorting-game {
+    padding-bottom: 2rem;
   }
 
   .sorting-game__control-button {
@@ -467,8 +470,8 @@
   }
 
   .sorting-game__rule-column {
-    background: rgba(30, 41, 59, 0.85);
-    border-color: rgba(148, 163, 184, 0.28);
+    background: none;
+    border-color: transparent;
   }
 
   .sorting-game__rule-title {
@@ -489,7 +492,31 @@
   }
 
   .sorting-game__queue-placeholder {
-    color: #cbd5f5;
+    background: rgba(15, 23, 42, 0.82);
+    border-color: rgba(129, 140, 248, 0.45);
+    box-shadow: 0 18px 40px rgba(15, 23, 42, 0.55);
+    color: #e2e8f0;
+  }
+
+  .sorting-game__queue-placeholder:hover,
+  .sorting-game__queue-placeholder:focus-visible {
+    background: rgba(30, 41, 59, 0.88);
+    border-color: rgba(165, 180, 252, 0.65);
+    box-shadow: 0 26px 52px rgba(15, 23, 42, 0.58);
+  }
+
+  .sorting-game__queue-placeholder:disabled {
+    background: rgba(15, 23, 42, 0.72);
+    border-color: rgba(148, 163, 184, 0.35);
+    box-shadow: 0 16px 34px rgba(15, 23, 42, 0.5);
+    color: rgba(203, 213, 225, 0.85);
+    opacity: 0.85;
+  }
+
+  .sorting-game__queue-placeholder:disabled:hover {
+    background: rgba(15, 23, 42, 0.72);
+    border-color: rgba(148, 163, 184, 0.35);
+    box-shadow: 0 16px 34px rgba(15, 23, 42, 0.5);
   }
 
   .sorting-game__control-button {


### PR DESCRIPTION
## Summary
- expand the sorting queue placeholder button so the entire queue box can be clicked to start the game
- refresh the placeholder styling in dark mode for higher contrast and consistent hover/focus feedback

## Testing
- npm run build *(fails: existing `.d.ts` artifacts in src trigger TS6305 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68ecfdefb18c832fabbe8c0120ae1161