### PR TITLE
Prevent sorting game hints from overlapping the scoreboard

### DIFF
--- a/src/games/sorting/SortingGame.css
+++ b/src/games/sorting/SortingGame.css
@@ -438,6 +438,18 @@
 
 /* Animations removed because queue positioning relies on inline transforms */
 
+@media (max-width: 1100px) {
+  .sorting-game__play-area {
+    grid-template-columns: minmax(0, 1fr);
+    justify-items: center;
+    gap: clamp(0.9rem, 3vw, 1.5rem);
+  }
+
+  .sorting-game__rule-column {
+    max-width: 320px;
+  }
+}
+
 @media (max-width: 900px) {
   .sorting-game__play-area {
     grid-template-columns: minmax(0, 1fr);


### PR DESCRIPTION
## Summary
- stack the sorting game rule columns earlier to keep them from spilling over the scoreboard on medium screens

## Testing
- npm run build *(fails: existing TS6305 errors about missing declaration outputs)*

------
https://chatgpt.com/codex/tasks/task_e_68ed3cdd7a9c832f9514b47bd176b576