### PR TITLE
Place game scoreboards below gameplay sections

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -116,15 +116,9 @@
 }
 
 .game-page__grid {
-  display: grid;
+  display: flex;
+  flex-direction: column;
   gap: clamp(1rem, 3vw, 1.75rem);
-}
-
-@media (min-width: 900px) {
-  .game-page__grid {
-    grid-template-columns: minmax(220px, 280px) minmax(0, 1fr);
-    align-items: start;
-  }
 }
 
 .game-scoreboard {

--- a/src/ReactionTest.tsx
+++ b/src/ReactionTest.tsx
@@ -110,6 +110,24 @@ export default function ReactionTest({ onExit }: ReactionTestProps) {
       </header>
 
       <div className="game-page__grid reaction-test__layout">
+        <div className="reaction-test__content">
+          <div
+            className={`reaction-test__play-area reaction-test__play-area--${phase}`}
+            onClick={handleClick}
+            role="button"
+            tabIndex={0}
+            onKeyDown={(event) => {
+              if (event.key === 'Enter' || event.key === ' ') {
+                event.preventDefault()
+                handleClick()
+              }
+            }}
+          >
+            <span className="reaction-test__message">{textByPhase(phase, reactionTime)}</span>
+          </div>
+          <p className="reaction-test__hint">Tip: Brug mellemrumstasten for at starte og reagere hurtigt.</p>
+        </div>
+
         <aside className="game-scoreboard">
           <h2 className="game-scoreboard__title">Scoreboard</h2>
           {highScores.length === 0 ? (
@@ -128,24 +146,6 @@ export default function ReactionTest({ onExit }: ReactionTestProps) {
             De fem hurtigste reaktionstider gemmes lokalt i denne browser.
           </p>
         </aside>
-
-        <div className="reaction-test__content">
-          <div
-            className={`reaction-test__play-area reaction-test__play-area--${phase}`}
-            onClick={handleClick}
-            role="button"
-            tabIndex={0}
-            onKeyDown={(event) => {
-              if (event.key === 'Enter' || event.key === ' ') {
-                event.preventDefault()
-                handleClick()
-              }
-            }}
-          >
-            <span className="reaction-test__message">{textByPhase(phase, reactionTime)}</span>
-          </div>
-          <p className="reaction-test__hint">Tip: Brug mellemrumstasten for at starte og reagere hurtigt.</p>
-        </div>
       </div>
     </section>
   )

--- a/src/games/sorting/SortingGame.css
+++ b/src/games/sorting/SortingGame.css
@@ -438,6 +438,18 @@
 
 /* Animations removed because queue positioning relies on inline transforms */
 
+@media (max-width: 1100px) {
+  .sorting-game__play-area {
+    grid-template-columns: minmax(0, 1fr);
+    justify-items: center;
+    gap: clamp(0.9rem, 3vw, 1.5rem);
+  }
+
+  .sorting-game__rule-column {
+    max-width: 320px;
+  }
+}
+
 @media (max-width: 900px) {
   .sorting-game__play-area {
     grid-template-columns: minmax(0, 1fr);

--- a/src/games/sorting/SortingGame.tsx
+++ b/src/games/sorting/SortingGame.tsx
@@ -441,27 +441,6 @@ export default function SortingGame({ onExit }: SortingGameProps) {
       </header>
 
       <div className="game-page__grid sorting-game__layout">
-        <aside className="game-scoreboard">
-          <h2 className="game-scoreboard__title">Scoreboard</h2>
-          <dl className="game-scoreboard__rows">
-            <div className="game-scoreboard__row">
-              <dt>Bedste score</dt>
-              <dd>{bestScore}</dd>
-            </div>
-            <div className="game-scoreboard__row">
-              <dt>Sidste score</dt>
-              <dd>{lastResult ? lastResult.score : '–'}</dd>
-            </div>
-            <div className="game-scoreboard__row">
-              <dt>Sorterede figurer</dt>
-              <dd>{lastResult ? lastResult.sorted : '–'}</dd>
-            </div>
-          </dl>
-          <p className="game-scoreboard__footnote">
-            Rekorden gemmes lokalt og opdateres automatisk, når du slår den.
-          </p>
-        </aside>
-
         <div className="sorting-game__content">
           <div className="sorting-game__actions sorting-game__actions--top">
             {phase === 'idle' && (
@@ -632,6 +611,27 @@ export default function SortingGame({ onExit }: SortingGameProps) {
             </div>
           )}
         </div>
+
+        <aside className="game-scoreboard">
+          <h2 className="game-scoreboard__title">Scoreboard</h2>
+          <dl className="game-scoreboard__rows">
+            <div className="game-scoreboard__row">
+              <dt>Bedste score</dt>
+              <dd>{bestScore}</dd>
+            </div>
+            <div className="game-scoreboard__row">
+              <dt>Sidste score</dt>
+              <dd>{lastResult ? lastResult.score : '–'}</dd>
+            </div>
+            <div className="game-scoreboard__row">
+              <dt>Sorterede figurer</dt>
+              <dd>{lastResult ? lastResult.sorted : '–'}</dd>
+            </div>
+          </dl>
+          <p className="game-scoreboard__footnote">
+            Rekorden gemmes lokalt og opdateres automatisk, når du slår den.
+          </p>
+        </aside>
       </div>
     </section>
   )

--- a/src/screens/MemoryGame.tsx
+++ b/src/screens/MemoryGame.tsx
@@ -331,27 +331,6 @@ export default function MemoryGame() {
       </header>
 
       <div className="game-page__grid memory-game__layout">
-        <aside className="game-scoreboard">
-          <h2 className="game-scoreboard__title">Scoreboard</h2>
-          <dl className="game-scoreboard__rows">
-            <div className="game-scoreboard__row">
-              <dt>Færreste træk</dt>
-              <dd>{currentHighscore.bestMoves !== null ? currentHighscore.bestMoves : '–'}</dd>
-            </div>
-            <div className="game-scoreboard__row">
-              <dt>Hurtigste tid</dt>
-              <dd>
-                {currentHighscore.bestTimeMs !== null
-                  ? `${formatSeconds(currentHighscore.bestTimeMs)} s`
-                  : '–'}
-              </dd>
-            </div>
-          </dl>
-          <p className="game-scoreboard__footnote">
-            Resultaterne gemmes pr. sværhedsgrad på denne enhed.
-          </p>
-        </aside>
-
         <div className="memory-game__content">
           <div
             style={{
@@ -524,6 +503,27 @@ export default function MemoryGame() {
         })}
           </div>
         </div>
+
+        <aside className="game-scoreboard">
+          <h2 className="game-scoreboard__title">Scoreboard</h2>
+          <dl className="game-scoreboard__rows">
+            <div className="game-scoreboard__row">
+              <dt>Færreste træk</dt>
+              <dd>{currentHighscore.bestMoves !== null ? currentHighscore.bestMoves : '–'}</dd>
+            </div>
+            <div className="game-scoreboard__row">
+              <dt>Hurtigste tid</dt>
+              <dd>
+                {currentHighscore.bestTimeMs !== null
+                  ? `${formatSeconds(currentHighscore.bestTimeMs)} s`
+                  : '–'}
+              </dd>
+            </div>
+          </dl>
+          <p className="game-scoreboard__footnote">
+            Resultaterne gemmes pr. sværhedsgrad på denne enhed.
+          </p>
+        </aside>
       </div>
     </section>
   )


### PR DESCRIPTION
## Summary
- stack the game page layout vertically so scoreboards render after the interactive content
- move the reaction, memory, and sorting scoreboards beneath their respective gameplay areas so they sit at the bottom of the screen

## Testing
- npm run build *(fails: existing TS6305 errors about missing declaration outputs)*

------
https://chatgpt.com/codex/tasks/task_e_68ed3cdd7a9c832f9514b47bd176b576