### PR TITLE
Fix TypeScript build process to unblock deployment

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "tsc && vite build",
+    "build": "tsc -p tsconfig.app.json --noEmit && vite build",
     "preview": "vite preview",
     "test": "echo \"Tests are not configured yet\""
   },

--- a/src/games/sorting/SortingGame.tsx
+++ b/src/games/sorting/SortingGame.tsx
@@ -525,7 +525,6 @@ export default function SortingGame({ onExit }: SortingGameProps) {
                 type="button"
                 className="sorting-game__queue-placeholder"
                 onClick={startGame}
-                disabled={phase === 'running' || phase === 'paused'}
               >
                 Tryk her eller på &quot;Start spil&quot; for at begynde at sortere figurerne.
               </button>

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import ReactDOM from 'react-dom/client'
 import { BrowserRouter } from 'react-router-dom'
-import App from './App.tsx'
+import App from './App'
 import './index.css'
 
 ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -1,12 +1,22 @@
 {
   "compilerOptions": {
-    "composite": true,
-    "tsBuildInfoFile": "./node_modules/.tsbuildinfo",
+    "target": "ESNext",
+    "useDefineForClassFields": true,
+    "lib": ["DOM", "DOM.Iterable", "ESNext"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "esModuleInterop": false,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
     "module": "ESNext",
     "moduleResolution": "Node",
     "resolveJsonModule": true,
     "isolatedModules": true,
+    "noEmit": true,
     "jsx": "react-jsx",
+    "composite": true,
+    "tsBuildInfoFile": "./node_modules/.tsbuildinfo",
     "types": ["vite/client"]
   },
   "include": ["src"]

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,22 +1,5 @@
 {
-  "compilerOptions": {
-    "target": "ESNext",
-    "useDefineForClassFields": true,
-    "lib": ["DOM", "DOM.Iterable", "ESNext"],
-    "allowJs": false,
-    "skipLibCheck": true,
-    "esModuleInterop": false,
-    "allowSyntheticDefaultImports": true,
-    "strict": true,
-    "forceConsistentCasingInFileNames": true,
-    "module": "ESNext",
-    "moduleResolution": "Node",
-    "resolveJsonModule": true,
-    "isolatedModules": true,
-    "noEmit": true,
-    "jsx": "react-jsx"
-  },
-  "include": ["src"],
+  "files": [],
   "references": [
     { "path": "./tsconfig.node.json" },
     { "path": "./tsconfig.app.json" }


### PR DESCRIPTION
## Summary
- move the TypeScript compiler options into `tsconfig.app.json` and turn the root config into a project reference aggregator so the build can run
- update the build script to type-check through `tsconfig.app.json` and clean up the `App` import extension
- resolve the `SortingGame` placeholder button type error uncovered by the stricter build

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ed5d1378f4832f9acf076ab7ac66e9