### PR TITLE
Update home page title to Fokus 2.0

### DIFF
--- a/src/components/BrandLogo.tsx
+++ b/src/components/BrandLogo.tsx
@@ -10,6 +10,7 @@ type BrandLogoProps = {
   size?: number
   wordmarkSize?: string
   showWordmark?: boolean
+  wordmarkText?: string
   className?: string
   style?: CSSProperties
 }
@@ -20,6 +21,7 @@ export default function BrandLogo({
   size = 64,
   wordmarkSize = '1.5rem',
   showWordmark = true,
+  wordmarkText = 'Fokus',
   className = '',
   style,
 }: BrandLogoProps) {
@@ -41,8 +43,10 @@ export default function BrandLogo({
 
   return (
     <Component className={classes} style={inlineStyle}>
-      <img src={LOGO_URL} alt="Fokus" className="brand-logo__mark" />
-      {showWordmark ? <span className="brand-logo__wordmark">Fokus</span> : null}
+      <img src={LOGO_URL} alt={wordmarkText} className="brand-logo__mark" />
+      {showWordmark ? (
+        <span className="brand-logo__wordmark">{wordmarkText}</span>
+      ) : null}
     </Component>
   )
 }

--- a/src/screens/Home.tsx
+++ b/src/screens/Home.tsx
@@ -53,6 +53,7 @@ export default function Home() {
           align="center"
           size={96}
           wordmarkSize="clamp(2.4rem, 6vw, 3.4rem)"
+          wordmarkText="Fokus 2.0"
           style={{ marginBottom: '0.5rem' }}
         />
         <p>Vælg et spil for at komme i gang.</p>


### PR DESCRIPTION
## Summary
- allow the BrandLogo component to accept custom wordmark text
- update the home screen to display "Fokus 2.0" as the main title

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ee6e4c9c8c832f8621c174a30b378f