### PR TITLE
Persist game data with Vercel KV and Blob

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,27 @@ Et React + TypeScript projekt oprettet med Vite.
    npm run dev
    ```
 
+### Lokal udvikling med Vercel storage
+
+Vercel KV og Blob kører via serverless routes i `/api`. For at teste lokalt skal du køre
+Vercel CLI samtidig med Vite:
+
+1. Start Vercel dev-serveren (kræver installeret Vercel CLI):
+   ```bash
+   vercel dev --listen 3000
+   ```
+2. Start Vite og peg API-kaldene mod Vercel-dev instansen:
+   ```bash
+   VITE_API_BASE_URL=http://localhost:3000 npm run dev
+   ```
+
+Sørg for at konfigurere følgende miljøvariabler på Vercel (og lokalt, hvis du bruger `vercel dev`):
+
+- `KV_REST_API_URL`
+- `KV_REST_API_TOKEN`
+- `KV_REST_API_READ_ONLY_TOKEN`
+- `BLOB_READ_WRITE_TOKEN`
+
 ## Scripts
 
 - `npm run dev` – starter Vite udviklingsserveren.
@@ -23,4 +44,4 @@ Et React + TypeScript projekt oprettet med Vite.
 ## Spil
 
 - **Reaktionstest** – klik så hurtigt som muligt, når skærmen skifter farve, og jagt dine hurtigste reaktionstider.
-- **Memory** – vend to kort ad gangen og find alle par. Du kan vælge mellem tre sværhedsgrader: Let (4 × 4, 8 par), Mellem (5 × 4, 10 par) og Svær (6 × 4, 12 par). Spillet holder styr på dine bedste tider og færreste træk pr. niveau via localStorage.
+- **Memory** – vend to kort ad gangen og find alle par. Du kan vælge mellem tre sværhedsgrader: Let (4 × 4, 8 par), Mellem (5 × 4, 10 par) og Svær (6 × 4, 12 par). Spillet holder nu styr på dine bedste tider og færreste træk pr. niveau via Vercel KV og lagrer en JSON-log i Vercel Blob for persistens.

--- a/api/memory-highscores.ts
+++ b/api/memory-highscores.ts
@@ -1,0 +1,180 @@
+import type { VercelRequest, VercelResponse } from '@vercel/node'
+import { kv } from '@vercel/kv'
+import { get, put } from '@vercel/blob'
+
+type MemoryDifficulty = 'easy' | 'medium' | 'hard'
+
+interface MemoryHighscoreEntry {
+  bestMoves: number | null
+  bestTimeMs: number | null
+}
+
+type MemoryHighscores = Record<MemoryDifficulty, MemoryHighscoreEntry>
+
+const KV_KEY = 'memory-game:highscores'
+const BLOB_PATH = 'memory-game/highscores.json'
+
+const defaultEntry: MemoryHighscoreEntry = { bestMoves: null, bestTimeMs: null }
+
+function createDefaultHighscores(): MemoryHighscores {
+  return {
+    easy: { ...defaultEntry },
+    medium: { ...defaultEntry },
+    hard: { ...defaultEntry },
+  }
+}
+
+function sanitizeEntry(value: unknown): MemoryHighscoreEntry {
+  if (!value || typeof value !== 'object') {
+    return { ...defaultEntry }
+  }
+
+  const record = value as Record<string, unknown>
+  const bestMoves = record.bestMoves
+  const bestTimeMs = record.bestTimeMs
+
+  return {
+    bestMoves:
+      typeof bestMoves === 'number' && Number.isFinite(bestMoves)
+        ? bestMoves
+        : null,
+    bestTimeMs:
+      typeof bestTimeMs === 'number' && Number.isFinite(bestTimeMs)
+        ? bestTimeMs
+        : null,
+  }
+}
+
+function sanitizeHighscores(value: unknown): MemoryHighscores {
+  if (!value || typeof value !== 'object') {
+    return createDefaultHighscores()
+  }
+
+  const source = value as Record<string, unknown>
+
+  return {
+    easy: sanitizeEntry(source.easy),
+    medium: sanitizeEntry(source.medium),
+    hard: sanitizeEntry(source.hard),
+  }
+}
+
+async function readFromBlob(): Promise<MemoryHighscores | null> {
+  try {
+    const result = await get(BLOB_PATH)
+    const text = await result.blob.text()
+    const parsed = JSON.parse(text) as unknown
+    return sanitizeHighscores(parsed)
+  } catch (error) {
+    console.error('Kunne ikke læse memory-highscores fra Vercel Blob.', error)
+    return null
+  }
+}
+
+async function writeToBlob(highscores: MemoryHighscores): Promise<void> {
+  try {
+    await put(BLOB_PATH, JSON.stringify(highscores), {
+      access: 'private',
+      contentType: 'application/json',
+      addRandomSuffix: false,
+    })
+  } catch (error) {
+    console.error('Kunne ikke skrive memory-highscores til Vercel Blob.', error)
+  }
+}
+
+async function handleGet(res: VercelResponse) {
+  try {
+    const stored = await kv.get<MemoryHighscores | null>(KV_KEY)
+    if (stored) {
+      const highscores = sanitizeHighscores(stored)
+      res.status(200).json({ highscores })
+      return
+    }
+
+    const blobHighscores = await readFromBlob()
+    if (blobHighscores) {
+      await kv.set(KV_KEY, blobHighscores)
+      res.status(200).json({ highscores: blobHighscores })
+      return
+    }
+
+    const defaults = createDefaultHighscores()
+    res.status(200).json({ highscores: defaults })
+  } catch (error) {
+    console.error('Fejl ved hentning af memory-highscores.', error)
+    res.status(500).json({ error: 'Kunne ikke hente highscores.' })
+  }
+}
+
+async function parseRequestBody(req: VercelRequest): Promise<unknown> {
+  if (req.body !== undefined) {
+    if (typeof req.body === 'string') {
+      try {
+        return JSON.parse(req.body)
+      } catch (error) {
+        console.error('Kunne ikke parse tekst-body for memory-highscores.', error)
+        return null
+      }
+    }
+
+    if (req.body && typeof req.body === 'object') {
+      return req.body
+    }
+  }
+
+  const chunks: Uint8Array[] = []
+  for await (const chunk of req) {
+    chunks.push(typeof chunk === 'string' ? Buffer.from(chunk) : chunk)
+  }
+
+  if (chunks.length === 0) {
+    return null
+  }
+
+  const buffer = Buffer.concat(chunks)
+
+  try {
+    return JSON.parse(buffer.toString('utf-8'))
+  } catch (error) {
+    console.error('Kunne ikke parse stream-body for memory-highscores.', error)
+    return null
+  }
+}
+
+async function handlePost(req: VercelRequest, res: VercelResponse) {
+  try {
+    const body = await parseRequestBody(req)
+    const payload = body && typeof body === 'object' ? (body as Record<string, unknown>) : null
+    const submitted = payload?.highscores ?? payload
+    const highscores = sanitizeHighscores(submitted)
+
+    await kv.set(KV_KEY, highscores)
+    await writeToBlob(highscores)
+
+    res.status(200).json({ highscores })
+  } catch (error) {
+    console.error('Fejl ved opdatering af memory-highscores.', error)
+    res.status(500).json({ error: 'Kunne ikke opdatere highscores.' })
+  }
+}
+
+export default async function handler(
+  req: VercelRequest,
+  res: VercelResponse,
+): Promise<void> {
+  res.setHeader('Cache-Control', 'no-store')
+
+  if (req.method === 'GET') {
+    await handleGet(res)
+    return
+  }
+
+  if (req.method === 'POST') {
+    await handlePost(req, res)
+    return
+  }
+
+  res.setHeader('Allow', 'GET, POST')
+  res.status(405).json({ error: 'Method not allowed' })
+}

--- a/api/sorting-best-score.ts
+++ b/api/sorting-best-score.ts
@@ -1,0 +1,114 @@
+import type { VercelRequest, VercelResponse } from '@vercel/node'
+import { kv } from '@vercel/kv'
+
+const KV_KEY = 'sorting-game:best-score'
+
+function parseBestScore(value: unknown): number | null {
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return value
+  }
+
+  if (typeof value === 'string') {
+    const parsed = Number.parseInt(value, 10)
+    return Number.isFinite(parsed) ? parsed : null
+  }
+
+  return null
+}
+
+async function readBestScore(): Promise<number> {
+  try {
+    const stored = await kv.get<unknown>(KV_KEY)
+    const parsed = parseBestScore(stored)
+    return parsed ?? 0
+  } catch (error) {
+    console.error('Kunne ikke hente Sorting-rekorden fra Vercel KV.', error)
+    return 0
+  }
+}
+
+async function parseRequestBody(req: VercelRequest): Promise<unknown> {
+  if (req.body !== undefined) {
+    if (typeof req.body === 'string') {
+      try {
+        return JSON.parse(req.body)
+      } catch (error) {
+        console.error('Kunne ikke parse tekst-body for Sorting-rekorden.', error)
+        return null
+      }
+    }
+
+    if (req.body && typeof req.body === 'object') {
+      return req.body
+    }
+  }
+
+  const chunks: Uint8Array[] = []
+  for await (const chunk of req) {
+    chunks.push(typeof chunk === 'string' ? Buffer.from(chunk) : chunk)
+  }
+
+  if (chunks.length === 0) {
+    return null
+  }
+
+  const buffer = Buffer.concat(chunks)
+
+  try {
+    return JSON.parse(buffer.toString('utf-8'))
+  } catch (error) {
+    console.error('Kunne ikke parse stream-body for Sorting-rekorden.', error)
+    return null
+  }
+}
+
+async function handleGet(res: VercelResponse) {
+  const bestScore = await readBestScore()
+  res.status(200).json({ bestScore })
+}
+
+async function handlePost(req: VercelRequest, res: VercelResponse) {
+  try {
+    const body = await parseRequestBody(req)
+    const payload = body && typeof body === 'object' ? (body as Record<string, unknown>) : null
+    const submittedScore = parseBestScore(payload?.bestScore ?? payload)
+
+    if (submittedScore === null || submittedScore < 0) {
+      res.status(400).json({ error: 'Ugyldig score.' })
+      return
+    }
+
+    const currentBest = await readBestScore()
+
+    if (submittedScore <= currentBest) {
+      res.status(200).json({ bestScore: currentBest })
+      return
+    }
+
+    await kv.set(KV_KEY, submittedScore)
+    res.status(200).json({ bestScore: submittedScore })
+  } catch (error) {
+    console.error('Kunne ikke opdatere Sorting-rekorden i Vercel KV.', error)
+    res.status(500).json({ error: 'Kunne ikke opdatere score.' })
+  }
+}
+
+export default async function handler(
+  req: VercelRequest,
+  res: VercelResponse,
+): Promise<void> {
+  res.setHeader('Cache-Control', 'no-store')
+
+  if (req.method === 'GET') {
+    await handleGet(res)
+    return
+  }
+
+  if (req.method === 'POST') {
+    await handlePost(req, res)
+    return
+  }
+
+  res.setHeader('Allow', 'GET, POST')
+  res.status(405).json({ error: 'Method not allowed' })
+}

--- a/package.json
+++ b/package.json
@@ -10,6 +10,9 @@
     "test": "echo \"Tests are not configured yet\""
   },
   "dependencies": {
+    "@vercel/blob": "^0.24.1",
+    "@vercel/kv": "^1.0.1",
+    "@vercel/node": "^3.1.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-router-dom": "^6.26.2"

--- a/src/utils/apiBase.ts
+++ b/src/utils/apiBase.ts
@@ -1,0 +1,10 @@
+const rawBaseUrl = (import.meta.env?.VITE_API_BASE_URL ?? '') as string
+const normalizedBaseUrl = rawBaseUrl.endsWith('/') ? rawBaseUrl.slice(0, -1) : rawBaseUrl
+
+export function getApiUrl(path: string): string {
+  const normalizedPath = path.startsWith('/') ? path : `/${path}`
+  if (!normalizedBaseUrl) {
+    return normalizedPath
+  }
+  return `${normalizedBaseUrl}${normalizedPath}`
+}

--- a/src/utils/sortingBestScore.ts
+++ b/src/utils/sortingBestScore.ts
@@ -1,0 +1,44 @@
+import { getApiUrl } from './apiBase'
+
+export async function loadSortingBestScore(): Promise<number> {
+  try {
+    const response = await fetch(getApiUrl('/api/sorting-best-score'))
+
+    if (!response.ok) {
+      throw new Error(`Serveren svarede med status ${response.status}`)
+    }
+
+    const payload = (await response.json()) as { bestScore?: unknown } | undefined
+    const value = payload?.bestScore
+
+    const numeric =
+      typeof value === 'number'
+        ? value
+        : typeof value === 'string'
+          ? Number.parseInt(value, 10)
+          : Number.NaN
+
+    return Number.isFinite(numeric) ? numeric : 0
+  } catch (error) {
+    console.error('Kunne ikke indlæse Sorting-rekorden fra serveren.', error)
+    return 0
+  }
+}
+
+export async function saveSortingBestScore(bestScore: number): Promise<void> {
+  try {
+    const response = await fetch(getApiUrl('/api/sorting-best-score'), {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ bestScore }),
+    })
+
+    if (!response.ok) {
+      throw new Error(`Serveren svarede med status ${response.status}`)
+    }
+  } catch (error) {
+    console.error('Kunne ikke gemme Sorting-rekorden på serveren.', error)
+  }
+}


### PR DESCRIPTION
## Summary
- replace browser localStorage for memory and sorting highscores with async helpers that call serverless API routes backed by Vercel KV
- add Vercel serverless functions for memory highscores (including a blob backup) and sorting best score, using the official SDKs
- document the new storage flow, expose an API URL helper, and declare the required Vercel packages

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68f50ee4f37c832f94641407fc1dd5ef