### PR TITLE
Add Odd One Out mini-game

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,6 +7,7 @@ import SortingGameScreen from './screens/SortingGameScreen'
 import MeditationHubScreen from './screens/MeditationHubScreen'
 import MeditationBoxBreathingScreen from './screens/MeditationBoxBreathingScreen'
 import MeditationYogaCandleScreen from './screens/MeditationYogaCandleScreen'
+import OddOneOutScreen from './screens/OddOneOutScreen'
 
 function AppLayout() {
   return (
@@ -23,6 +24,7 @@ function App() {
         <Route index element={<Home />} />
         <Route path="memory" element={<MemoryGame />} />
         <Route path="sorting" element={<SortingGameScreen />} />
+        <Route path="odd-one-out" element={<OddOneOutScreen />} />
         <Route path="reaction-test" element={<ReactionTestScreen />} />
         <Route path="meditation">
           <Route index element={<MeditationHubScreen />} />

--- a/src/index.css
+++ b/src/index.css
@@ -27,6 +27,233 @@ a {
   border: 0;
 }
 
+/* Tailwind-inspirerede hjælpeklasser til Odd One Out */
+.mx-auto {
+  margin-left: auto;
+  margin-right: auto;
+}
+
+.w-full {
+  width: 100%;
+}
+
+.max-w-4xl {
+  max-width: 56rem;
+}
+
+.space-y-6 {
+  display: flex;
+  flex-direction: column;
+}
+
+.space-y-6 > :not([hidden]) ~ :not([hidden]) {
+  margin-top: 1.5rem;
+}
+
+.flex {
+  display: flex;
+}
+
+.flex-wrap {
+  flex-wrap: wrap;
+}
+
+.items-center {
+  align-items: center;
+}
+
+.justify-between {
+  justify-content: space-between;
+}
+
+.gap-3 {
+  gap: 0.75rem;
+}
+
+.gap-4 {
+  gap: 1rem;
+}
+
+.gap-6 {
+  gap: 1.5rem;
+}
+
+.grid {
+  display: grid;
+}
+
+.rounded-xl {
+  border-radius: 0.75rem;
+}
+
+.rounded-2xl {
+  border-radius: 1rem;
+}
+
+.rounded-3xl {
+  border-radius: 1.5rem;
+}
+
+.shadow-md {
+  box-shadow: 0 16px 32px rgba(15, 23, 42, 0.12);
+}
+
+.shadow-lg {
+  box-shadow: 0 22px 40px rgba(15, 23, 42, 0.16);
+}
+
+.shadow-xl {
+  box-shadow: 0 28px 60px rgba(15, 23, 42, 0.22);
+}
+
+.shadow-inner {
+  box-shadow: inset 0 2px 6px rgba(15, 23, 42, 0.12);
+}
+
+.bg-white {
+  background-color: rgba(255, 255, 255, 0.92);
+}
+
+.bg-sky-500 {
+  background: linear-gradient(135deg, #0ea5e9, #38bdf8);
+}
+
+.bg-teal-500 {
+  background: linear-gradient(135deg, #0d9488, #14b8a6);
+}
+
+.bg-sky-50 {
+  background-color: rgba(186, 230, 253, 0.55);
+}
+
+.text-white {
+  color: #ffffff;
+}
+
+.text-slate-600 {
+  color: #475569;
+}
+
+.text-slate-500 {
+  color: #64748b;
+}
+
+.text-sky-900 {
+  color: #0f172a;
+}
+
+.text-emerald-600 {
+  color: #059669;
+}
+
+.text-rose-600 {
+  color: #e11d48;
+}
+
+.text-sm {
+  font-size: 0.875rem;
+  line-height: 1.5;
+}
+
+.text-xs {
+  font-size: 0.75rem;
+  letter-spacing: 0.08em;
+  line-height: 1.2;
+}
+
+.text-base {
+  font-size: 1rem;
+  line-height: 1.6;
+}
+
+.text-lg {
+  font-size: 1.125rem;
+  line-height: 1.6;
+}
+
+.text-xl {
+  font-size: 1.25rem;
+  line-height: 1.5;
+}
+
+.text-2xl {
+  font-size: 1.5rem;
+  line-height: 1.4;
+}
+
+.uppercase {
+  text-transform: uppercase;
+}
+
+.tracking-wide {
+  letter-spacing: 0.18em;
+}
+
+.font-semibold {
+  font-weight: 600;
+}
+
+.px-4 {
+  padding-left: 1rem;
+  padding-right: 1rem;
+}
+
+.px-6 {
+  padding-left: 1.5rem;
+  padding-right: 1.5rem;
+}
+
+.py-2 {
+  padding-top: 0.55rem;
+  padding-bottom: 0.55rem;
+}
+
+.py-3 {
+  padding-top: 0.75rem;
+  padding-bottom: 0.75rem;
+}
+
+.py-5 {
+  padding-top: 1.25rem;
+  padding-bottom: 1.25rem;
+}
+
+.mt-1 {
+  margin-top: 0.25rem;
+}
+
+.mt-3 {
+  margin-top: 0.75rem;
+}
+
+.mt-4 {
+  margin-top: 1rem;
+}
+
+.mt-6 {
+  margin-top: 1.5rem;
+}
+
+.pt-4 {
+  padding-top: 1rem;
+}
+
+.pt-6 {
+  padding-top: 1.5rem;
+}
+
+.text-center {
+  text-align: center;
+}
+
+.border {
+  border: 1px solid rgba(148, 163, 184, 0.35);
+}
+
+.border-sky-200 {
+  border-color: rgba(125, 211, 252, 0.65);
+}
+
 .meditation-page {
   display: flex;
   flex-direction: column;

--- a/src/screens/Home.tsx
+++ b/src/screens/Home.tsx
@@ -42,6 +42,13 @@ const games: GameDefinition[] = [
     path: '/sorting',
     startLabel: 'Start sorteringsspil',
   },
+  {
+    id: 'odd-one-out',
+    name: 'Odd One Out',
+    description: 'Find figuren der skiller sig ud fra mængden på tid.',
+    path: '/odd-one-out',
+    startLabel: 'Start Odd One Out',
+  },
 ]
 
 export default function Home() {

--- a/src/screens/OddOneOutScreen.tsx
+++ b/src/screens/OddOneOutScreen.tsx
@@ -1,0 +1,124 @@
+import { useCallback, useEffect, useState } from 'react'
+import { useNavigate } from 'react-router-dom'
+import motion from 'framer-motion'
+import OddOneOutGame from '../games/oddoneout/OddOneOutGame'
+import {
+  getOddOneOutScores,
+  type OddOneOutScoreEntry,
+} from '../utils/oddOneOutScores'
+
+function formatScoreTimestamp(timestamp: number): string {
+  const date = new Date(timestamp)
+  if (Number.isNaN(date.getTime())) {
+    return ''
+  }
+
+  return date.toLocaleString('da-DK', {
+    day: '2-digit',
+    month: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+  })
+}
+
+export default function OddOneOutScreen() {
+  const navigate = useNavigate()
+  const [scores, setScores] = useState<OddOneOutScoreEntry[]>([])
+  const [isLoading, setIsLoading] = useState(true)
+  const [hasFinished, setHasFinished] = useState(false)
+  const [lastScore, setLastScore] = useState<number | null>(null)
+
+  const refreshScores = useCallback(async () => {
+    setIsLoading(true)
+    const nextScores = await getOddOneOutScores(5)
+    setScores(nextScores)
+    setIsLoading(false)
+  }, [])
+
+  useEffect(() => {
+    void refreshScores()
+  }, [refreshScores])
+
+  const handleGameFinished = useCallback(
+    (score: number) => {
+      setHasFinished(true)
+      setLastScore(score)
+      void refreshScores()
+    },
+    [refreshScores],
+  )
+
+  const handleScoreSubmitted = useCallback(() => {
+    void refreshScores()
+  }, [refreshScores])
+
+  return (
+    <div className="mx-auto w-full max-w-4xl space-y-6">
+      <OddOneOutGame
+        onExit={() => navigate('/')}
+        onGameFinished={handleGameFinished}
+        onScoreSubmitted={handleScoreSubmitted}
+      />
+
+      <motion.section
+        className="rounded-3xl bg-white px-6 py-5 shadow-xl"
+        initial={{ opacity: 0, transform: 'translateY(12px)' }}
+        animate={{ opacity: 1, transform: 'translateY(0)' }}
+        transition={{ duration: 0.45, delay: 0.2 }}
+      >
+        <header className="flex flex-wrap items-center justify-between gap-4">
+          <div>
+            <h3 className="text-xl font-semibold text-sky-900">Odd One Out – Top 5</h3>
+            <p className="text-sm text-slate-600">
+              {hasFinished
+                ? 'De bedste resultater fra Fokus-fællesskabet opdateres automatisk her.'
+                : 'Afslut et spil for at se de aktuelle topresultater og gemme dit eget.'}
+            </p>
+          </div>
+          {lastScore !== null ? (
+            <span className="rounded-xl bg-sky-500 px-4 py-2 text-sm font-semibold text-white shadow-md">
+              Din seneste score: {lastScore}
+            </span>
+          ) : null}
+        </header>
+
+        <div className="mt-4">
+          {isLoading ? (
+            <p className="text-sm text-slate-600">Indlæser highscores…</p>
+          ) : scores.length === 0 ? (
+            <p className="text-sm text-slate-600">
+              Ingen gemte resultater endnu. Vær den første til at sætte en rekord!
+            </p>
+          ) : (
+            <ol className="mt-3">
+              {scores.map((entry, index) => (
+                <li
+                  key={`${entry.name}-${entry.ts}`}
+                  className="flex flex-wrap items-center justify-between gap-4 rounded-2xl"
+                  style={{
+                    background: 'linear-gradient(135deg, rgba(186, 230, 253, 0.35), rgba(125, 211, 252, 0.55))',
+                    padding: '0.85rem 1.2rem',
+                    boxShadow: '0 18px 28px rgba(15, 23, 42, 0.12)',
+                    border: '1px solid rgba(125, 211, 252, 0.45)',
+                    marginTop: index === 0 ? 0 : '0.85rem',
+                  }}
+                >
+                  <div className="flex items-center gap-3 text-sky-900">
+                    <span className="rounded-xl bg-white px-4 py-2 text-sm font-semibold text-sky-900 shadow-md">
+                      #{index + 1}
+                    </span>
+                    <span className="text-lg font-semibold text-sky-900">{entry.name}</span>
+                  </div>
+                  <div className="flex flex-wrap items-center gap-3 text-sm text-slate-600">
+                    <span className="font-semibold text-sky-900">{entry.score} point</span>
+                    <span>{formatScoreTimestamp(entry.ts)}</span>
+                  </div>
+                </li>
+              ))}
+            </ol>
+          )}
+        </div>
+      </motion.section>
+    </div>
+  )
+}

--- a/src/utils/oddOneOutScores.ts
+++ b/src/utils/oddOneOutScores.ts
@@ -1,0 +1,109 @@
+import { getApiUrl } from './apiBase'
+
+export interface OddOneOutScoreEntry {
+  name: string
+  score: number
+  ts: number
+}
+
+const SCORES_ENDPOINT = '/api/odd-one-out-scores'
+
+function sanitizeEntry(value: unknown): OddOneOutScoreEntry | null {
+  if (!value || typeof value !== 'object') {
+    return null
+  }
+
+  const record = value as Record<string, unknown>
+  const rawName = typeof record.name === 'string' ? record.name.trim() : ''
+  const rawScore = record.score
+  const rawTimestamp = record.ts
+
+  if (!rawName) {
+    return null
+  }
+
+  const score =
+    typeof rawScore === 'number' && Number.isFinite(rawScore) && rawScore >= 0
+      ? Math.floor(rawScore)
+      : null
+  const ts =
+    typeof rawTimestamp === 'number' && Number.isFinite(rawTimestamp)
+      ? Math.floor(rawTimestamp)
+      : Date.now()
+
+  if (score === null) {
+    return null
+  }
+
+  return {
+    name: rawName.slice(0, 64),
+    score,
+    ts,
+  }
+}
+
+function sanitizeScores(value: unknown): OddOneOutScoreEntry[] {
+  if (!Array.isArray(value)) {
+    return []
+  }
+
+  const parsed = value
+    .map((item) => sanitizeEntry(item))
+    .filter((entry): entry is OddOneOutScoreEntry => entry !== null)
+
+  parsed.sort((a, b) => {
+    if (b.score !== a.score) {
+      return b.score - a.score
+    }
+    return a.ts - b.ts
+  })
+
+  return parsed
+}
+
+export async function postOddOneOutScore(name: string, score: number): Promise<void> {
+  try {
+    const response = await fetch(getApiUrl(SCORES_ENDPOINT), {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        name: name.trim(),
+        score,
+      }),
+    })
+
+    if (!response.ok) {
+      throw new Error(`Serveren svarede med status ${response.status}`)
+    }
+  } catch (error) {
+    console.error('Kunne ikke gemme Odd One Out-highscore på serveren.', error)
+    throw error instanceof Error
+      ? error
+      : new Error('Kunne ikke gemme Odd One Out-highscore på serveren.')
+  }
+}
+
+export async function getOddOneOutScores(
+  limit = 5,
+): Promise<OddOneOutScoreEntry[]> {
+  const safeLimit = Number.isFinite(limit) ? Math.max(1, Math.floor(limit)) : 5
+  const endpointPath = `${SCORES_ENDPOINT}?limit=${safeLimit}`
+
+  try {
+    const response = await fetch(getApiUrl(endpointPath))
+
+    if (!response.ok) {
+      throw new Error(`Serveren svarede med status ${response.status}`)
+    }
+
+    const payload = (await response.json()) as { scores?: unknown } | undefined
+    const data = payload?.scores ?? payload
+
+    return sanitizeScores(data)
+  } catch (error) {
+    console.error('Kunne ikke hente Odd One Out-highscores fra serveren.', error)
+    return []
+  }
+}

--- a/src/vendor/framer-motion.tsx
+++ b/src/vendor/framer-motion.tsx
@@ -1,0 +1,179 @@
+import {
+  forwardRef,
+  useEffect,
+  useMemo,
+  useState,
+  type CSSProperties,
+  type ElementType,
+  type MouseEvent,
+  type PointerEvent,
+  type Ref,
+} from 'react'
+
+type MotionStyle = CSSProperties
+
+interface MotionTransition {
+  duration?: number
+  delay?: number
+  easing?: string
+}
+
+type BaseMotionProps<T extends keyof JSX.IntrinsicElements> = Omit<
+  JSX.IntrinsicElements[T],
+  'style'
+> & {
+  style?: CSSProperties
+  initial?: MotionStyle
+  animate?: MotionStyle
+  whileHover?: MotionStyle
+  whileTap?: MotionStyle
+  transition?: MotionTransition
+}
+
+function transitionToStyle(transition?: MotionTransition): CSSProperties {
+  if (!transition) {
+    return {}
+  }
+
+  const {
+    duration = 0.35,
+    easing = 'cubic-bezier(0.22, 1, 0.36, 1)',
+    delay = 0,
+  } = transition
+
+  return {
+    transitionProperty:
+      'opacity, transform, background-color, color, box-shadow, border-color, filter',
+    transitionDuration: `${duration}s`,
+    transitionTimingFunction: easing,
+    transitionDelay: `${delay}s`,
+  }
+}
+
+function createMotionComponent<T extends keyof JSX.IntrinsicElements>(tag: T) {
+  type Props = BaseMotionProps<T>
+
+  const MotionComponent = forwardRef<HTMLElement, Props>((props, ref) => {
+    const motionProps = props as BaseMotionProps<T>
+
+    const {
+      initial,
+      animate,
+      whileHover,
+      whileTap,
+      transition,
+      style,
+      onMouseEnter,
+      onMouseLeave,
+      onPointerDown,
+      onPointerUp,
+      onPointerLeave,
+      ...rest
+    } = motionProps
+
+    const [isAnimating, setIsAnimating] = useState(false)
+    const [isHovering, setIsHovering] = useState(false)
+    const [isTapping, setIsTapping] = useState(false)
+
+    useEffect(() => {
+      if (typeof window === 'undefined') {
+        setIsAnimating(true)
+        return
+      }
+
+      setIsAnimating(false)
+      const frame = window.requestAnimationFrame(() => setIsAnimating(true))
+      return () => window.cancelAnimationFrame(frame)
+    }, [animate, initial])
+
+    const baseStyle = useMemo(() => {
+      if (!isAnimating) {
+        return { ...(initial ?? animate ?? {}) }
+      }
+      return { ...(animate ?? initial ?? {}) }
+    }, [animate, initial, isAnimating])
+
+    const finalStyle = useMemo(() => {
+      const composed: CSSProperties = {
+        ...transitionToStyle(transition),
+        ...baseStyle,
+      }
+
+      if (isHovering && whileHover) {
+        Object.assign(composed, whileHover)
+      }
+
+      if (isTapping && whileTap) {
+        Object.assign(composed, whileTap)
+      }
+
+      if (style) {
+        Object.assign(composed, style)
+      }
+
+      return composed
+    }, [baseStyle, isHovering, isTapping, style, transition, whileHover, whileTap])
+
+    const Element = tag as unknown as ElementType
+
+    return (
+      <Element
+        ref={ref as Ref<unknown>}
+        {...(rest as Record<string, unknown>)}
+        style={finalStyle}
+        onMouseEnter={(event: MouseEvent<any>) => {
+          setIsHovering(true)
+          onMouseEnter?.(event as never)
+        }}
+        onMouseLeave={(event: MouseEvent<any>) => {
+          setIsHovering(false)
+          onMouseLeave?.(event as never)
+        }}
+        onPointerDown={(event: PointerEvent<any>) => {
+          setIsTapping(true)
+          onPointerDown?.(event as never)
+        }}
+        onPointerUp={(event: PointerEvent<any>) => {
+          setIsTapping(false)
+          onPointerUp?.(event as never)
+        }}
+        onPointerLeave={(event: PointerEvent<any>) => {
+          setIsTapping(false)
+          onPointerLeave?.(event as never)
+        }}
+      />
+    )
+  })
+
+  MotionComponent.displayName = `Motion.${String(tag)}`
+
+  return MotionComponent
+}
+
+type MotionComponent<T extends keyof JSX.IntrinsicElements> = ReturnType<
+  typeof createMotionComponent<T>
+>
+
+const motionCache: Partial<
+  Record<keyof JSX.IntrinsicElements, MotionComponent<keyof JSX.IntrinsicElements>>
+> = {}
+
+export const motion = new Proxy(motionCache, {
+  get(target, key: keyof JSX.IntrinsicElements) {
+    if (!target[key]) {
+      target[key] = createMotionComponent(key)
+    }
+    return target[key]!
+  },
+}) as {
+  [K in keyof JSX.IntrinsicElements]: MotionComponent<K>
+}
+
+export const AnimatePresence: React.FC<{ children?: React.ReactNode }> = ({
+  children,
+}) => <>{children}</>
+
+export type { MotionTransition }
+export type MotionProps<T extends keyof JSX.IntrinsicElements> = BaseMotionProps<T>
+
+export default motion

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -17,7 +17,11 @@
     "jsx": "react-jsx",
     "composite": true,
     "tsBuildInfoFile": "./node_modules/.tsbuildinfo",
-    "types": ["vite/client"]
+    "types": ["vite/client"],
+    "baseUrl": ".",
+    "paths": {
+      "framer-motion": ["./src/vendor/framer-motion"]
+    }
   },
   "include": ["src"]
 }

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -5,7 +5,11 @@
     "module": "ESNext",
     "moduleResolution": "Node",
     "resolveJsonModule": true,
-    "allowSyntheticDefaultImports": true
+    "allowSyntheticDefaultImports": true,
+    "baseUrl": ".",
+    "paths": {
+      "framer-motion": ["./src/vendor/framer-motion"]
+    }
   },
   "include": ["vite.config.ts"]
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,7 +1,13 @@
+import path from 'node:path'
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: [react()],
+  resolve: {
+    alias: {
+      'framer-motion': path.resolve(__dirname, './src/vendor/framer-motion.tsx'),
+    },
+  },
 })


### PR DESCRIPTION
## Summary
- add the Odd One Out mini-game with progressive difficulty and animated UI
- expose KV-backed score utilities for storing and reading highscores
- wire up the new screen with routing, home navigation, and leaderboard view

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68f626950f08832fa2a6dca73d5b1cad