### PR TITLE
Enable login form to trigger login state

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -28,7 +28,7 @@ function App() {
         className="app"
         style={{ background: 'linear-gradient(135deg, #E6F4FA 0%, #FDFEFF 100%)' }}
       >
-        <LoginScreen onSkip={() => setIsLoggedIn(true)} />
+        <LoginScreen onSkip={() => setIsLoggedIn(true)} onLogin={() => setIsLoggedIn(true)} />
       </main>
     )
   }

--- a/src/screens/LoginScreen.tsx
+++ b/src/screens/LoginScreen.tsx
@@ -3,15 +3,17 @@ import BrandLogo from '../components/BrandLogo'
 
 type LoginScreenProps = {
   onSkip: () => void
+  onLogin: () => void
 }
 
-export default function LoginScreen({ onSkip }: LoginScreenProps) {
+export default function LoginScreen({ onSkip, onLogin }: LoginScreenProps) {
   const [email, setEmail] = useState('')
   const [password, setPassword] = useState('')
 
   const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault()
     // Placeholder for future authentication logic
+    onLogin()
   }
 
   return (


### PR DESCRIPTION
## Summary
- add an onLogin callback to the login screen and invoke it when the form is submitted
- have the app pass the same state update for both skip and standard logins so the app unlocks

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68f67a6110fc832fa50fbec451793842