### PR TITLE
Fix Odd One Out reset timer reinitialization

### DIFF
--- a/src/games/oddoneout/OddOneOutGame.tsx
+++ b/src/games/oddoneout/OddOneOutGame.tsx
@@ -314,6 +314,7 @@ export default function OddOneOutGame({
   onScoreSubmitted,
 }: OddOneOutGameProps) {
   const [phase, setPhase] = useState<OddOneOutPhase>('idle')
+  const [gameInstance, setGameInstance] = useState(0)
   const [board, setBoard] = useState<BoardState>(() => generateBoard(0))
   const [timeLeft, setTimeLeft] = useState(GAME_DURATION_SECONDS)
   const [score, setScore] = useState(0)
@@ -382,10 +383,11 @@ export default function OddOneOutGame({
     return () => {
       clearTimer()
     }
-  }, [clearTimer, finishGame, phase])
+  }, [clearTimer, finishGame, phase, gameInstance])
 
   const handleStart = useCallback(() => {
     clearTimer()
+    setGameInstance((value) => value + 1)
     endTimeRef.current = Date.now() + GAME_DURATION_SECONDS * 1000
     setPhase('running')
     setBoard(generateBoard(0))


### PR DESCRIPTION
## Summary
- track a game instance counter so the timer effect re-initializes when restarting
- increment the counter on start so reset while running recreates the countdown interval

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68f680144c84832f9800440880740e28