### PR TITLE
Align Odd One Out button styling with app UI

### DIFF
--- a/src/games/oddoneout/OddOneOutGame.css
+++ b/src/games/oddoneout/OddOneOutGame.css
@@ -77,59 +77,36 @@
   flex-wrap: wrap;
 }
 
-.odd-one-out-game__primary-button,
-.odd-one-out-game__secondary-button,
-.odd-one-out-game__ghost-button {
-  font-family: inherit;
-  font-weight: 600;
-  font-size: 0.95rem;
-  border-radius: 999px;
-  padding: 0.65rem 1.6rem;
-  cursor: pointer;
-  transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease,
-    border-color 0.2s ease, color 0.2s ease;
-}
-
 .odd-one-out-game__primary-button {
-  background: linear-gradient(135deg, #0ea5e9, #38bdf8);
-  border: 1px solid rgba(125, 211, 252, 0.6);
+  align-items: center;
+  background: linear-gradient(135deg, #1d4ed8, #3b82f6);
+  border: none;
+  border-radius: 999px;
+  box-shadow: 0 18px 36px rgba(37, 99, 235, 0.25);
   color: #fff;
-  box-shadow: 0 18px 32px rgba(14, 165, 233, 0.25);
+  cursor: pointer;
+  display: inline-flex;
+  font-family: inherit;
+  font-size: 1rem;
+  font-weight: 700;
+  gap: 0.35rem;
+  justify-content: center;
+  padding: 0.85rem 2.2rem;
+  text-decoration: none;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, filter 0.2s ease;
 }
 
-.odd-one-out-game__primary-button:hover {
-  transform: translateY(-1px);
-  box-shadow: 0 22px 36px rgba(14, 165, 233, 0.28);
+.odd-one-out-game__primary-button:hover,
+.odd-one-out-game__primary-button:focus-visible {
+  transform: translateY(-2px);
+  box-shadow: 0 22px 46px rgba(37, 99, 235, 0.35);
+  outline: none;
 }
 
 .odd-one-out-game__primary-button:disabled {
   cursor: not-allowed;
   opacity: 0.75;
   box-shadow: none;
-}
-
-.odd-one-out-game__secondary-button {
-  background: linear-gradient(135deg, #14b8a6, #0d9488);
-  border: 1px solid rgba(94, 234, 212, 0.4);
-  color: #fff;
-  box-shadow: 0 16px 28px rgba(13, 148, 136, 0.22);
-}
-
-.odd-one-out-game__secondary-button:disabled {
-  opacity: 0.75;
-  cursor: not-allowed;
-  box-shadow: none;
-}
-
-.odd-one-out-game__ghost-button {
-  background: rgba(255, 255, 255, 0.8);
-  border: 1px solid rgba(14, 165, 233, 0.25);
-  color: #0f172a;
-  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.75);
-}
-
-.odd-one-out-game__ghost-button:hover {
-  background: rgba(241, 245, 249, 0.95);
 }
 
 .odd-one-out-game__status-text {

--- a/src/games/oddoneout/OddOneOutGame.tsx
+++ b/src/games/oddoneout/OddOneOutGame.tsx
@@ -11,6 +11,7 @@ import motion from 'framer-motion'
 import BrandLogo from '../../components/BrandLogo'
 import { postOddOneOutScore } from '../../utils/oddOneOutScores'
 import { MAX_GRID_SIZE } from './constants'
+import './OddOneOutGame.css'
 
 type OddOneOutPhase = 'idle' | 'running' | 'finished'
 
@@ -516,11 +517,11 @@ export default function OddOneOutGame({
           </div>
         </header>
 
-        <div className="flex flex-wrap items-center justify-between gap-3 pt-4">
+        <div className="odd-one-out-game__actions flex flex-wrap items-center justify-between gap-3 pt-4">
           <div className="flex items-center gap-3">
             <button
               type="button"
-              className="rounded-xl bg-sky-500 px-4 py-2 font-semibold text-white shadow-md"
+              className="odd-one-out-game__primary-button"
               onClick={phase === 'running' ? handleReset : handleStart}
             >
               {phase === 'running' ? 'Nulstil' : 'Start spil'}
@@ -532,11 +533,7 @@ export default function OddOneOutGame({
             )}
           </div>
           {onExit ? (
-            <button
-              type="button"
-              className="rounded-xl bg-teal-500 px-4 py-2 font-semibold text-white shadow-md"
-              onClick={onExit}
-            >
+            <button type="button" className="menu__back-button" onClick={onExit}>
               Tilbage til menu
             </button>
           ) : null}


### PR DESCRIPTION
## Summary
- import the Odd One Out game styles so the start button can use the shared gradient design
- restyle the game action buttons to match the existing UI patterns and reuse the global back button styling

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68f755515f18832fa676e5c31197fe92