### PR TITLE
Add PWA manifest and service worker for installable app

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,8 +2,19 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" type="image/svg+xml" href="/brand-logo.png" />
+    <link rel="icon" type="image/png" href="/brand-logo.png" />
+    <link rel="icon" type="image/svg+xml" href="/brand-logo.svg" />
+    <link rel="apple-touch-icon" href="/brand-logo.png" />
+    <link rel="manifest" href="/manifest.webmanifest" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="theme-color" content="#0f172a" />
+    <meta name="application-name" content="Fokus 2.0" />
+    <meta name="apple-mobile-web-app-capable" content="yes" />
+    <meta name="apple-mobile-web-app-status-bar-style" content="default" />
+    <meta
+      name="description"
+      content="Install Fokus 2.0 to sharpen your concentration with fast-paced brain-training games."
+    />
     <title>Fokus 2.0</title>
   </head>
   <body>

--- a/public/manifest.webmanifest
+++ b/public/manifest.webmanifest
@@ -1,0 +1,29 @@
+{
+  "name": "Fokus 2.0",
+  "short_name": "Fokus",
+  "description": "Fokus helps you sharpen concentration with engaging brain-training games.",
+  "lang": "en",
+  "start_url": "/",
+  "scope": "/",
+  "display": "standalone",
+  "orientation": "portrait",
+  "background_color": "#0f172a",
+  "theme_color": "#0f172a",
+  "icons": [
+    {
+      "src": "/brand-logo.png",
+      "sizes": "192x192",
+      "type": "image/png"
+    },
+    {
+      "src": "/brand-logo.png",
+      "sizes": "512x512",
+      "type": "image/png"
+    },
+    {
+      "src": "/brand-logo.svg",
+      "sizes": "any",
+      "type": "image/svg+xml"
+    }
+  ]
+}

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,0 +1,48 @@
+const CACHE_NAME = 'fokus-cache-v1'
+const ASSETS_TO_CACHE = [
+  '/',
+  '/index.html',
+  '/manifest.webmanifest',
+  '/brand-logo.png',
+  '/brand-logo.svg'
+]
+
+self.addEventListener('install', (event) => {
+  event.waitUntil(
+    caches
+      .open(CACHE_NAME)
+      .then((cache) => cache.addAll(ASSETS_TO_CACHE))
+      .then(() => self.skipWaiting()),
+  )
+})
+
+self.addEventListener('activate', (event) => {
+  event.waitUntil(
+    caches
+      .keys()
+      .then((keys) =>
+        Promise.all(
+          keys
+            .filter((key) => key !== CACHE_NAME)
+            .map((key) => caches.delete(key)),
+        ),
+      )
+      .then(() => self.clients.claim()),
+  )
+})
+
+self.addEventListener('fetch', (event) => {
+  if (event.request.method !== 'GET') {
+    return
+  }
+
+  event.respondWith(
+    fetch(event.request)
+      .then((response) => {
+        const responseClone = response.clone()
+        caches.open(CACHE_NAME).then((cache) => cache.put(event.request, responseClone))
+        return response
+      })
+      .catch(() => caches.match(event.request).then((cached) => cached || caches.match('/'))),
+  )
+})

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -11,3 +11,11 @@ ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
     </BrowserRouter>
   </React.StrictMode>,
 )
+
+if ('serviceWorker' in navigator) {
+  window.addEventListener('load', () => {
+    navigator.serviceWorker.register('/sw.js').catch((error) => {
+      console.error('Service worker registration failed:', error)
+    })
+  })
+}


### PR DESCRIPTION
## Summary
- add a web app manifest and update HTML metadata so Fokus can be installed on mobile
- introduce a service worker to cache core assets for offline startup and register it in the client

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68fe7a7d6570832fb3e578f70938d85d