### PR TITLE
Fix service worker HTML fallback only for navigation

### DIFF
--- a/public/sw.js
+++ b/public/sw.js
@@ -43,6 +43,18 @@ self.addEventListener('fetch', (event) => {
         caches.open(CACHE_NAME).then((cache) => cache.put(event.request, responseClone))
         return response
       })
-      .catch(() => caches.match(event.request).then((cached) => cached || caches.match('/'))),
+      .catch((error) =>
+        caches.match(event.request).then((cached) => {
+          if (cached) {
+            return cached
+          }
+
+          if (event.request.mode === 'navigate') {
+            return caches.match('/')
+          }
+
+          throw error
+        }),
+      ),
   )
 })


### PR DESCRIPTION
## Summary
- update the service worker fetch handler to only return the cached HTML shell on navigation requests
- ensure failed non-navigation requests either use their cached response or rethrow the original network error

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68ff3c4b5c00832f8202fd4b2cb4a8aa