### PR TITLE
Stabilize layout to prevent viewport drift

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -3,13 +3,26 @@
 }
 
 .app {
+  --app-padding: clamp(2rem, 4vw, 4rem);
+  position: relative;
+  width: 100%;
+  height: 100%;
   min-height: 100vh;
+  padding: var(--app-padding);
+  box-sizing: border-box;
   background: radial-gradient(circle at top, #f8fbff, #dce7ff);
   display: grid;
   place-items: center;
-  padding: clamp(2rem, 4vw, 4rem);
   font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
   color: #0f172a;
+  overflow: hidden;
+}
+
+@supports (height: 100dvh) {
+  .app {
+    min-height: 100dvh;
+    height: 100dvh;
+  }
 }
 
 .brand-logo {
@@ -48,6 +61,10 @@
   box-shadow: 0 24px 60px rgba(15, 23, 42, 0.15);
   padding: clamp(2rem, 5vw, 3rem);
   backdrop-filter: blur(8px);
+  max-height: calc(100% - (var(--app-padding, 2rem) * 2));
+  overflow-y: auto;
+  overscroll-behavior: contain;
+  scrollbar-gutter: stable;
 }
 
 .menu__header {

--- a/src/index.css
+++ b/src/index.css
@@ -6,9 +6,29 @@
   background-color: #f5f7fb;
 }
 
+html,
 body {
+  height: 100%;
   margin: 0;
-  min-height: 100vh;
+  overflow: hidden;
+  background-color: #f5f7fb;
+  overscroll-behavior: none;
+}
+
+#root {
+  position: fixed;
+  inset: 0;
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  height: 100%;
+  isolation: isolate;
+}
+
+#root > * {
+  flex: 1 1 auto;
+  min-height: 0;
+  min-width: 0;
 }
 
 a {


### PR DESCRIPTION
## Summary
- lock the application viewport by fixing the root container and preventing body overscroll
- update the app shell to use fixed-height sizing, overflow control, and consistent padding for every screen
- ensure menu panels scroll internally without moving the global frame

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ff3d5445d8832f8df0bc0c6f9585ea