### PR TITLE
Add timed Puzzle Blox session with scoreboard and level cap

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -12,10 +12,11 @@
   box-sizing: border-box;
   background: radial-gradient(circle at top, #f8fbff, #dce7ff);
   display: grid;
-  place-items: center;
+  justify-items: center;
+  align-items: flex-start;
   font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
   color: #0f172a;
-  overflow: hidden;
+  overflow: auto;
 }
 
 @supports (height: 100dvh) {

--- a/src/games/puzzleblox/PuzzleBloxGame.css
+++ b/src/games/puzzleblox/PuzzleBloxGame.css
@@ -12,6 +12,103 @@
   overflow: hidden;
 }
 
+.puzzle-blox__content {
+  display: grid;
+  gap: clamp(1.5rem, 3vw, 2rem);
+  align-items: flex-start;
+}
+
+@media (min-width: 960px) {
+  .puzzle-blox__content {
+    grid-template-columns: minmax(0, 1fr) minmax(260px, 320px);
+  }
+}
+
+@media (max-width: 959px) {
+  .puzzle-blox__content {
+    grid-template-columns: 1fr;
+  }
+}
+
+.puzzle-blox__main {
+  display: flex;
+  flex-direction: column;
+  gap: clamp(1.25rem, 3vw, 1.75rem);
+}
+
+.puzzle-blox__scoreboard {
+  position: relative;
+}
+
+.puzzle-blox__panel--intro {
+  text-align: left;
+  gap: 1rem;
+}
+
+.puzzle-blox__panel--intro h2 {
+  margin-bottom: 0.35rem;
+}
+
+.puzzle-blox__panel--intro p {
+  margin: 0;
+  color: #334155;
+  line-height: 1.6;
+}
+
+.puzzle-blox__primary-button {
+  background: linear-gradient(135deg, #22d3ee, #0ea5e9);
+  border: none;
+  border-radius: 999px;
+  color: #0f172a;
+  cursor: pointer;
+  font-family: inherit;
+  font-size: 1rem;
+  font-weight: 600;
+  padding: 0.75rem 1.75rem;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+  box-shadow: 0 14px 30px rgba(14, 165, 233, 0.28);
+  align-self: flex-start;
+}
+
+.puzzle-blox__primary-button:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 16px 36px rgba(14, 165, 233, 0.36);
+}
+
+.puzzle-blox__primary-button:focus-visible {
+  outline: 3px solid rgba(59, 130, 246, 0.45);
+  outline-offset: 3px;
+}
+
+.puzzle-blox__summary {
+  background: rgba(255, 255, 255, 0.82);
+  border-radius: 1.25rem;
+  border: 1px solid rgba(148, 163, 184, 0.24);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.65), 0 16px 36px rgba(148, 163, 184, 0.22);
+  padding: clamp(1rem, 2.5vw, 1.5rem);
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  text-align: left;
+}
+
+.puzzle-blox__summary h2 {
+  margin: 0;
+  font-size: 1.3rem;
+}
+
+.puzzle-blox__summary p {
+  margin: 0;
+  color: #334155;
+  line-height: 1.6;
+}
+
+.puzzle-blox__actions {
+  display: flex;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
 .puzzle-blox__header {
   display: flex;
   align-items: center;

--- a/src/games/puzzleblox/PuzzleBloxGame.tsx
+++ b/src/games/puzzleblox/PuzzleBloxGame.tsx
@@ -13,10 +13,27 @@ interface PuzzleBloxGameProps {
   onExit?: () => void
 }
 
+type Phase = 'idle' | 'running' | 'finished'
+
+const GAME_DURATION_SECONDS = 40
+
+function formatTime(seconds: number): string {
+  const safeSeconds = Math.max(0, Math.floor(seconds))
+  const minutes = Math.floor(safeSeconds / 60)
+  const remainder = safeSeconds % 60
+  return `${minutes}:${remainder.toString().padStart(2, '0')}`
+}
+
 export default function PuzzleBloxGame({ onExit }: PuzzleBloxGameProps) {
   const audioContextRef = useRef<AudioContext | null>(null)
   const [showDebug, setShowDebug] = useState(false)
   const [attempt, setAttempt] = useState(0)
+  const [phase, setPhase] = useState<Phase>('idle')
+  const [sessionId, setSessionId] = useState(0)
+  const [timeRemaining, setTimeRemaining] = useState(GAME_DURATION_SECONDS)
+  const [levelsCompleted, setLevelsCompleted] = useState(0)
+  const [currentLevelIndex, setCurrentLevelIndex] = useState(0)
+  const timerRef = useRef<number | null>(null)
 
   const [levelSeed] = useState(() => {
     if (typeof window === 'undefined') {
@@ -123,6 +140,73 @@ export default function PuzzleBloxGame({ onExit }: PuzzleBloxGameProps) {
     [invalidLevel, showDebug],
   )
 
+  const stopTimer = useCallback(() => {
+    if (timerRef.current !== null) {
+      window.clearInterval(timerRef.current)
+      timerRef.current = null
+    }
+  }, [])
+
+  useEffect(() => {
+    return () => {
+      stopTimer()
+    }
+  }, [stopTimer])
+
+  useEffect(() => {
+    if (phase !== 'running') {
+      stopTimer()
+      return undefined
+    }
+
+    timerRef.current = window.setInterval(() => {
+      setTimeRemaining((previous) => {
+        if (previous <= 1) {
+          stopTimer()
+          setPhase('finished')
+          return 0
+        }
+
+        return previous - 1
+      })
+    }, 1000)
+
+    return () => {
+      stopTimer()
+    }
+  }, [phase, stopTimer])
+
+  const handleStartGame = useCallback(() => {
+    setSessionId((previous) => previous + 1)
+    setPhase('running')
+    setTimeRemaining(GAME_DURATION_SECONDS)
+    setLevelsCompleted(0)
+    setCurrentLevelIndex(0)
+  }, [])
+
+  const handleRestart = useCallback(() => {
+    handleStartGame()
+  }, [handleStartGame])
+
+  const handleLevelComplete = useCallback(
+    ({ completedLevelIndex, nextLevelIndex }: { completedLevelIndex: number; nextLevelIndex: number }) => {
+      setLevelsCompleted((previous) => Math.max(previous, completedLevelIndex + 1))
+      setCurrentLevelIndex(nextLevelIndex)
+    },
+    [],
+  )
+
+  const highestLevel = phase === 'idle' ? 0 : Math.max(levelsCompleted, currentLevelIndex + 1)
+  const scoreboardTime = phase === 'idle' ? formatTime(GAME_DURATION_SECONDS) : formatTime(timeRemaining)
+
+  const scoreboardFootnote = hasInvalidLevels
+    ? 'Generatoren arbejder på et nyt niveau…'
+    : phase === 'idle'
+      ? 'Start spillet for at begynde nedtællingen.'
+      : phase === 'running'
+        ? 'Fortsæt med at matche figurer, indtil tiden udløber.'
+        : 'Godt gået! Start igen for at forbedre din score.'
+
   return (
     <div className="puzzle-blox">
       <header className="puzzle-blox__header">
@@ -139,47 +223,117 @@ export default function PuzzleBloxGame({ onExit }: PuzzleBloxGameProps) {
         <h1>Puzzle Blox</h1>
       </header>
 
-      {hasInvalidLevels ? (
-        <div
-          className="puzzle-blox__panel puzzle-blox__panel--compact puzzle-blox__regenerating"
-          role="status"
-          aria-live="polite"
-        >
-          <p>Generatoren arbejder på et reachbart niveau…</p>
-          {showDebug && invalidLevel ? (
-            <TargetBoard
-              pattern={invalidLevel.target}
-              showDebug
-              debugMask={invalidMask ?? undefined}
-            />
-          ) : null}
+      <div className="puzzle-blox__content">
+        <div className="puzzle-blox__main">
+          {hasInvalidLevels ? (
+            <div
+              className="puzzle-blox__panel puzzle-blox__panel--compact puzzle-blox__regenerating"
+              role="status"
+              aria-live="polite"
+            >
+              <p>Generatoren arbejder på et reachbart niveau…</p>
+              {showDebug && invalidLevel ? (
+                <TargetBoard pattern={invalidLevel.target} showDebug debugMask={invalidMask ?? undefined} />
+              ) : null}
+            </div>
+          ) : (
+            <>
+              {phase === 'idle' ? (
+                <section className="puzzle-blox__panel puzzle-blox__panel--intro">
+                  <h2>Start Puzzle Blox</h2>
+                  <p>
+                    Tryk på &rdquo;Start spil&rdquo; for at få 40 sekunder til at løse så mange figurer som muligt.
+                    Du starter på niveau 1 og kan højest nå til niveau 5.
+                  </p>
+                  <button type="button" className="puzzle-blox__primary-button" onClick={handleStartGame}>
+                    Start spil
+                  </button>
+                </section>
+              ) : null}
+
+              {phase !== 'idle' ? (
+                <>
+                  <LevelManager
+                    key={sessionId}
+                    levels={activeLevels}
+                    onClickSound={playClickSound}
+                    onWinSound={playWinSound}
+                    showDebug={showDebug}
+                    isLocked={phase !== 'running'}
+                    onLevelComplete={handleLevelComplete}
+                  />
+
+                  <div className="puzzle-blox__instructions">
+                    Lav samme figur som vist øverst. Fjern overflødige blokke ved at trykke på dem.
+                  </div>
+
+                  {phase === 'finished' ? (
+                    <div className="puzzle-blox__summary" role="status" aria-live="polite">
+                      <h2>Tiden er gået!</h2>
+                      <p>
+                        Du nåede niveau {highestLevel} og gennemførte{' '}
+                        {levelsCompleted === 1 ? '1 niveau' : `${levelsCompleted} niveauer`}.
+                      </p>
+                      <div className="puzzle-blox__actions">
+                        <button
+                          type="button"
+                          className="puzzle-blox__primary-button"
+                          onClick={handleRestart}
+                        >
+                          Prøv igen
+                        </button>
+                      </div>
+                    </div>
+                  ) : null}
+
+                  <div className="puzzle-blox__debug-controls">
+                    <label className="puzzle-blox__debug-toggle">
+                      <input
+                        type="checkbox"
+                        checked={showDebug}
+                        onChange={(event) => setShowDebug(event.target.checked)}
+                      />
+                      Vis reachability debug
+                    </label>
+
+                    {showDebug && hasInvalidLevels ? (
+                      <div className="puzzle-blox__debug-warning">Ikke reach-bar – regenererer…</div>
+                    ) : null}
+                  </div>
+                </>
+              ) : null}
+            </>
+          )}
         </div>
-      ) : (
-        <LevelManager
-          levels={activeLevels}
-          onClickSound={playClickSound}
-          onWinSound={playWinSound}
-          showDebug={showDebug}
-        />
-      )}
 
-      <div className="puzzle-blox__instructions">
-        Lav samme figur som vist øverst. Fjern overflødige blokke ved at trykke på dem.
-      </div>
-
-      <div className="puzzle-blox__debug-controls">
-        <label className="puzzle-blox__debug-toggle">
-          <input
-            type="checkbox"
-            checked={showDebug}
-            onChange={(event) => setShowDebug(event.target.checked)}
-          />
-          Vis reachability debug
-        </label>
-
-        {showDebug && hasInvalidLevels ? (
-          <div className="puzzle-blox__debug-warning">Ikke reach-bar – regenererer…</div>
-        ) : null}
+        <aside className="game-scoreboard puzzle-blox__scoreboard">
+          <h2 className="game-scoreboard__title">Scoreboard</h2>
+          <dl className="game-scoreboard__rows">
+            <div className="game-scoreboard__row">
+              <dt>Tid tilbage</dt>
+              <dd>{scoreboardTime}</dd>
+            </div>
+            <div className="game-scoreboard__row">
+              <dt>Aktuelt niveau</dt>
+              <dd>
+                {hasInvalidLevels
+                  ? '–'
+                  : phase === 'idle'
+                    ? '–'
+                    : Math.min(currentLevelIndex + 1, activeLevels.length)}
+              </dd>
+            </div>
+            <div className="game-scoreboard__row">
+              <dt>Niveauer gennemført</dt>
+              <dd>
+                {phase === 'idle'
+                  ? 0
+                  : Math.min(levelsCompleted, activeLevels.length)}
+              </dd>
+            </div>
+          </dl>
+          <p className="game-scoreboard__footnote">{scoreboardFootnote}</p>
+        </aside>
       </div>
     </div>
   )

--- a/src/index.css
+++ b/src/index.css
@@ -10,7 +10,8 @@ html,
 body {
   height: 100%;
   margin: 0;
-  overflow: hidden;
+  overflow-x: hidden;
+  overflow-y: auto;
   background-color: #f5f7fb;
   overscroll-behavior: none;
 }
@@ -23,6 +24,7 @@ body {
   width: 100%;
   height: 100%;
   isolation: isolate;
+  overflow-y: auto;
 }
 
 #root > * {


### PR DESCRIPTION
## Summary
- allow the shell layout to scroll so Puzzle Blox controls remain reachable
- add a start flow, 40 second timer, and scoreboard to Puzzle Blox
- stop the Puzzle Blox level manager from looping past level 5 and lock input when time expires

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_69009469724c832f8be047e6385fa633