### PR TITLE
Update navigation copy and routine route

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -43,7 +43,7 @@ function App() {
         className="app"
         style={{ background: 'linear-gradient(135deg, #E6F4FA 0%, #FDFEFF 100%)' }}
       >
-        <LoginScreen onSkip={() => handleLogin('/')} onGoToRoutine={() => handleLogin('/focus')} />
+        <LoginScreen onSkip={() => handleLogin('/')} onGoToRoutine={() => handleLogin('/rutines')} />
       </main>
     )
   }
@@ -53,7 +53,7 @@ function App() {
       <Route element={<AppLayout />}>
         <Route index element={<Home />} />
         <Route path="memory" element={<MemoryGame />} />
-        <Route path="focus" element={<FocusRoutineScreen />} />
+        <Route path="rutines" element={<FocusRoutineScreen />} />
         <Route path="sorting" element={<SortingGameScreen />} />
         <Route path="odd-one-out" element={<OddOneOutScreen />} />
         <Route path="puzzle-blox" element={<PuzzleBloxScreen />} />

--- a/src/screens/LoginScreen.tsx
+++ b/src/screens/LoginScreen.tsx
@@ -13,9 +13,9 @@ export default function LoginScreen({ onSkip, onGoToRoutine }: LoginScreenProps)
         <header className="landing-header">
           <BrandLogo align="left" size={64} wordmarkSize="2rem" />
           <nav className="landing-nav" aria-label="Primary navigation">
-            <a href="#features">Features</a>
-            <a href="#rituals">Rituals</a>
-            <a href="#pricing">Pricing</a>
+            <a href="https://fokus-mu-snowy.vercel.app/">Fokus spil</a>
+            <a href="https://fokus-mu-snowy.vercel.app/rutines">Fokus Rutiner</a>
+            <a href="https://fokus-mu-snowy.vercel.app/meditation">Fokus meditation</a>
           </nav>
         </header>
 


### PR DESCRIPTION
## Summary
- rename the landing navigation labels to Fokus-specific names and link them to the production site
- update the internal routine route to /rutines and ensure the login flow uses the new path

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_690b43b9f0cc832f8220443587840f46