### PR TITLE
Align Fokus spil link with Kom i gang action

### DIFF
--- a/src/screens/LoginScreen.css
+++ b/src/screens/LoginScreen.css
@@ -34,14 +34,22 @@
   font-size: 1rem;
 }
 
-.landing-nav a {
+.landing-nav__link {
   color: #0f172a;
   text-decoration: none;
   position: relative;
   transition: color 0.2s ease;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  background: none;
+  border: none;
+  padding: 0;
+  font: inherit;
+  cursor: pointer;
 }
 
-.landing-nav a::after {
+.landing-nav__link::after {
   content: '';
   position: absolute;
   left: 0;
@@ -54,13 +62,13 @@
   transition: transform 0.2s ease;
 }
 
-.landing-nav a:hover,
-.landing-nav a:focus-visible {
+.landing-nav__link:hover,
+.landing-nav__link:focus-visible {
   color: #334155;
 }
 
-.landing-nav a:hover::after,
-.landing-nav a:focus-visible::after {
+.landing-nav__link:hover::after,
+.landing-nav__link:focus-visible::after {
   transform: scaleX(1);
 }
 

--- a/src/screens/LoginScreen.tsx
+++ b/src/screens/LoginScreen.tsx
@@ -13,9 +13,15 @@ export default function LoginScreen({ onSkip, onGoToRoutine }: LoginScreenProps)
         <header className="landing-header">
           <BrandLogo align="left" size={64} wordmarkSize="2rem" />
           <nav className="landing-nav" aria-label="Primary navigation">
-            <a href="https://fokus-mu-snowy.vercel.app/">Fokus spil</a>
-            <a href="https://fokus-mu-snowy.vercel.app/rutines">Fokus Rutiner</a>
-            <a href="https://fokus-mu-snowy.vercel.app/meditation">Fokus meditation</a>
+            <button type="button" className="landing-nav__link" onClick={onSkip}>
+              Fokus spil
+            </button>
+            <a className="landing-nav__link" href="https://fokus-mu-snowy.vercel.app/rutines">
+              Fokus Rutiner
+            </a>
+            <a className="landing-nav__link" href="https://fokus-mu-snowy.vercel.app/meditation">
+              Fokus meditation
+            </a>
           </nav>
         </header>
 


### PR DESCRIPTION
## Summary
- trigger the Kom i gang navigation behavior when clicking the Fokus spil header item
- align navigation styling so buttons and links share the same presentation

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_690b46982970832f86f82ccb3f095a73