### PR TITLE
Fix Fokus Rutiner nav link to trigger routine route

### DIFF
--- a/src/screens/LoginScreen.tsx
+++ b/src/screens/LoginScreen.tsx
@@ -16,9 +16,9 @@ export default function LoginScreen({ onSkip, onGoToRoutine }: LoginScreenProps)
             <button type="button" className="landing-nav__link" onClick={onSkip}>
               Fokus spil
             </button>
-            <a className="landing-nav__link" href="https://fokus-mu-snowy.vercel.app/rutines">
+            <button type="button" className="landing-nav__link" onClick={onGoToRoutine}>
               Fokus Rutiner
-            </a>
+            </button>
             <a className="landing-nav__link" href="https://fokus-mu-snowy.vercel.app/meditation">
               Fokus meditation
             </a>


### PR DESCRIPTION
## Summary
- update the login screen nav item for Fokus Rutiner to reuse the routine navigation handler

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_690b57c5ddec832f8ad4818454e79c66