### PR TITLE
Improve mobile home layout and routine styling

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -124,7 +124,7 @@
 .menu__grid {
   display: grid;
   gap: clamp(1rem, 3vw, 1.75rem);
-  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
 }
 
 .game-page {
@@ -262,6 +262,70 @@
   filter: saturate(0.6);
   opacity: 0.75;
   box-shadow: none;
+}
+
+@media (max-width: 768px) {
+  .menu {
+    width: min(100%, 560px);
+    border-radius: 1.25rem;
+    padding: clamp(1.5rem, 6vw, 2.25rem);
+    max-height: none;
+    box-shadow: 0 20px 45px rgba(15, 23, 42, 0.18);
+  }
+
+  .menu__header {
+    text-align: left;
+    margin-bottom: clamp(1.25rem, 6vw, 1.75rem);
+  }
+
+  .menu__header h1 {
+    font-size: clamp(2.2rem, 8vw, 3rem);
+    margin-bottom: 0.35rem;
+  }
+
+  .menu__header p {
+    font-size: clamp(1rem, 4vw, 1.1rem);
+    color: #334155;
+  }
+
+  .menu__grid {
+    gap: clamp(1rem, 5vw, 1.5rem);
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .menu__card {
+    padding: clamp(1rem, 6vw, 1.5rem);
+    gap: 0.85rem;
+  }
+
+  .menu__card h2 {
+    font-size: clamp(1.25rem, 6vw, 1.5rem);
+  }
+
+  .menu__card p {
+    font-size: 0.95rem;
+    line-height: 1.55;
+  }
+
+  .menu__primary-button {
+    width: 100%;
+    justify-content: center;
+  }
+}
+
+@media (max-width: 480px) {
+  .menu {
+    border-radius: 1rem;
+    padding: clamp(1.25rem, 6vw, 1.75rem);
+  }
+
+  .menu__header h1 {
+    font-size: clamp(2rem, 9vw, 2.4rem);
+  }
+
+  .menu__header p {
+    font-size: 0.95rem;
+  }
 }
 
 @media (prefers-color-scheme: dark) {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -36,7 +36,11 @@ function App() {
         className="app"
         style={{ background: 'linear-gradient(135deg, #E6F4FA 0%, #FDFEFF 100%)' }}
       >
-        <LoginScreen onSkip={() => handleLogin('/')} onGoToRoutine={() => handleLogin('/rutines')} />
+        <LoginScreen
+          onSkip={() => handleLogin('/')}
+          onGoToRoutine={() => handleLogin('/rutines')}
+          onGoToMeditation={() => handleLogin('/meditation/box-breathing')}
+        />
       </main>
     )
   }

--- a/src/screens/FocusRoutineScreen.css
+++ b/src/screens/FocusRoutineScreen.css
@@ -1,6 +1,6 @@
 .focus-page {
-  background: linear-gradient(160deg, #fdf6ee 0%, #e9f4fb 45%, #ffffff 100%);
-  color: #0f172a;
+  background: linear-gradient(160deg, #0f172a 0%, #1f2937 45%, #020617 100%);
+  color: #e2e8f0;
   min-height: 100vh;
   display: flex;
   flex-direction: column;
@@ -18,7 +18,7 @@
 .focus-hero__background {
   position: absolute;
   inset: 0;
-  background: linear-gradient(180deg, rgba(253, 246, 238, 0.95) 0%, rgba(233, 244, 251, 0.9) 65%, rgba(255, 255, 255, 0.95) 100%);
+  background: linear-gradient(180deg, rgba(15, 23, 42, 0.95) 0%, rgba(15, 23, 42, 0.85) 65%, rgba(2, 6, 23, 0.9) 100%);
   overflow: hidden;
   z-index: 0;
 }
@@ -28,7 +28,7 @@
   width: clamp(320px, 40vw, 460px);
   aspect-ratio: 1 / 1;
   border-radius: 50%;
-  background: radial-gradient(circle at 50% 50%, rgba(255, 255, 255, 0.9) 0%, #f9d69a 40%, #f4b38f 70%, rgba(249, 196, 139, 0) 100%);
+  background: radial-gradient(circle at 50% 50%, rgba(248, 250, 252, 0.7) 0%, rgba(254, 215, 102, 0.4) 45%, rgba(253, 186, 116, 0.25) 70%, rgba(253, 186, 116, 0) 100%);
   bottom: 12%;
   left: 50%;
   transform: translateX(-50%);
@@ -41,8 +41,8 @@
   left: -10%;
   width: 120%;
   height: clamp(140px, 18vw, 200px);
-  background: linear-gradient(180deg, rgba(255, 255, 255, 0) 0%, rgba(226, 232, 240, 0.6) 100%);
-  filter: blur(12px);
+  background: linear-gradient(180deg, rgba(59, 130, 246, 0) 0%, rgba(148, 163, 184, 0.35) 100%);
+  filter: blur(18px);
 }
 
 .focus-hero__ocean {
@@ -51,8 +51,8 @@
   left: 0;
   width: 100%;
   height: clamp(220px, 30vw, 300px);
-  background: linear-gradient(180deg, rgba(224, 242, 254, 0.9) 0%, rgba(186, 230, 253, 0.9) 50%, rgba(14, 165, 233, 0.25) 100%);
-  transform: translateY(20px);
+  background: linear-gradient(180deg, rgba(15, 118, 110, 0.45) 0%, rgba(14, 116, 144, 0.5) 50%, rgba(8, 47, 73, 0.6) 100%);
+  transform: translateY(24px);
 }
 
 .focus-hero__content {
@@ -68,7 +68,7 @@
   text-transform: uppercase;
   letter-spacing: 0.32em;
   font-size: 0.85rem;
-  color: rgba(15, 23, 42, 0.55);
+  color: rgba(148, 163, 184, 0.7);
 }
 
 .focus-hero__title {
@@ -81,7 +81,7 @@
   margin: 0;
   font-size: clamp(1.05rem, 2.8vw, 1.4rem);
   line-height: 1.7;
-  color: rgba(30, 41, 59, 0.82);
+  color: rgba(203, 213, 225, 0.82);
 }
 
 .focus-hero__cta {
@@ -91,17 +91,17 @@
   border: none;
   font-size: 1.05rem;
   font-weight: 600;
-  color: #0f172a;
+  color: #f8fafc;
   cursor: pointer;
-  background: linear-gradient(135deg, #a5f3fc 0%, #38bdf8 100%);
-  box-shadow: 0 24px 54px rgba(45, 212, 191, 0.22);
+  background: linear-gradient(135deg, rgba(37, 99, 235, 0.95) 0%, rgba(30, 64, 175, 0.95) 100%);
+  box-shadow: 0 24px 54px rgba(37, 99, 235, 0.35);
   transition: transform 0.25s ease, box-shadow 0.25s ease;
 }
 
 .focus-hero__cta:hover,
 .focus-hero__cta:focus-visible {
   transform: translateY(-3px);
-  box-shadow: 0 36px 72px rgba(56, 189, 248, 0.32);
+  box-shadow: 0 36px 72px rgba(30, 64, 175, 0.45);
 }
 
 .focus-section-header {
@@ -122,20 +122,21 @@
   margin: 0;
   font-size: 1.1rem;
   line-height: 1.65;
-  color: rgba(30, 41, 59, 0.78);
+  color: rgba(226, 232, 240, 0.78);
 }
 
 .focus-section-eyebrow {
   font-size: 0.95rem;
   text-transform: uppercase;
   letter-spacing: 0.18em;
-  color: rgba(15, 23, 42, 0.55);
+  color: rgba(148, 163, 184, 0.75);
 }
 
 .focus-routine {
   padding: clamp(3rem, 10vw, 6rem) clamp(1.5rem, 8vw, 6rem);
   display: grid;
   gap: clamp(2.5rem, 8vw, 4.5rem);
+  background: linear-gradient(180deg, rgba(15, 23, 42, 0.75) 0%, rgba(15, 23, 42, 0.6) 100%);
 }
 
 .focus-timeline {
@@ -150,25 +151,26 @@
   position: absolute;
   inset: 15% 0 auto;
   height: 2px;
-  background: linear-gradient(90deg, rgba(148, 163, 184, 0) 0%, rgba(148, 163, 184, 0.35) 50%, rgba(148, 163, 184, 0) 100%);
+  background: linear-gradient(90deg, rgba(59, 130, 246, 0) 0%, rgba(59, 130, 246, 0.25) 50%, rgba(59, 130, 246, 0) 100%);
   pointer-events: none;
 }
 
 .focus-timeline__card {
-  background: rgba(255, 255, 255, 0.88);
+  background: linear-gradient(160deg, rgba(30, 41, 59, 0.85), rgba(15, 23, 42, 0.92));
   border-radius: 28px;
   padding: 2rem;
   display: grid;
   gap: 1.1rem;
   position: relative;
-  box-shadow: 0 28px 60px rgba(15, 23, 42, 0.12);
-  backdrop-filter: blur(10px);
+  box-shadow: 0 28px 70px rgba(2, 6, 23, 0.55);
+  backdrop-filter: blur(12px);
+  border: 1px solid rgba(59, 130, 246, 0.15);
   transition: transform 0.3s ease, box-shadow 0.3s ease;
 }
 
 .focus-timeline__card.is-expanded {
   transform: translateY(-8px);
-  box-shadow: 0 36px 72px rgba(15, 23, 42, 0.16);
+  box-shadow: 0 36px 82px rgba(2, 6, 23, 0.6);
 }
 
 .focus-timeline__toggle {
@@ -196,7 +198,7 @@
   place-items: center;
   font-size: 2rem;
   border-radius: 20px;
-  background: linear-gradient(135deg, rgba(125, 211, 252, 0.32) 0%, rgba(255, 237, 213, 0.7) 100%);
+  background: linear-gradient(140deg, rgba(56, 189, 248, 0.25) 0%, rgba(37, 99, 235, 0.35) 100%);
 }
 
 .focus-timeline__label {
@@ -204,7 +206,7 @@
   font-size: 0.9rem;
   text-transform: uppercase;
   letter-spacing: 0.18em;
-  color: rgba(30, 41, 59, 0.6);
+  color: rgba(148, 163, 184, 0.75);
 }
 
 .focus-timeline__toggle h3 {
@@ -216,8 +218,8 @@
 .focus-timeline__chevron {
   width: 12px;
   height: 12px;
-  border-right: 2px solid rgba(15, 23, 42, 0.35);
-  border-bottom: 2px solid rgba(15, 23, 42, 0.35);
+  border-right: 2px solid rgba(226, 232, 240, 0.35);
+  border-bottom: 2px solid rgba(226, 232, 240, 0.35);
   transform: rotate(45deg);
   transition: transform 0.3s ease;
 }
@@ -230,7 +232,7 @@
   margin: 0;
   font-size: 1rem;
   line-height: 1.6;
-  color: rgba(30, 41, 59, 0.78);
+  color: rgba(226, 232, 240, 0.82);
 }
 
 .focus-timeline__details {
@@ -246,6 +248,7 @@
 .focus-timeline__details-title {
   font-weight: 600;
   margin: 0;
+  color: #f8fafc;
 }
 
 .focus-timeline__details ul {
@@ -259,10 +262,10 @@
   margin: 0;
   padding: 1rem 1.4rem;
   border-radius: 20px;
-  background: rgba(224, 242, 254, 0.65);
+  background: rgba(30, 64, 175, 0.35);
   display: grid;
   gap: 0.5rem;
-  color: rgba(15, 23, 42, 0.75);
+  color: rgba(226, 232, 240, 0.85);
   font-size: 0.95rem;
 }
 
@@ -277,7 +280,7 @@
   padding: clamp(3rem, 10vw, 6rem) clamp(1.5rem, 8vw, 6rem);
   display: grid;
   gap: clamp(2.5rem, 8vw, 4.5rem);
-  background: linear-gradient(180deg, rgba(255, 255, 255, 0.95) 0%, rgba(226, 232, 240, 0.5) 100%);
+  background: linear-gradient(180deg, rgba(15, 23, 42, 0.78) 0%, rgba(2, 6, 23, 0.9) 100%);
 }
 
 .focus-notifications__switcher {
@@ -291,8 +294,8 @@
   border: none;
   border-radius: 20px;
   padding: 0.9rem 1.5rem;
-  background: rgba(241, 245, 249, 0.75);
-  color: rgba(15, 23, 42, 0.75);
+  background: rgba(15, 23, 42, 0.7);
+  color: rgba(226, 232, 240, 0.8);
   font-weight: 600;
   display: grid;
   gap: 0.2rem;
@@ -304,12 +307,12 @@
 .focus-notifications__chip small {
   font-size: 0.75rem;
   font-weight: 500;
-  color: rgba(30, 41, 59, 0.6);
+  color: rgba(148, 163, 184, 0.75);
 }
 
 .focus-notifications__chip.is-active {
-  background: linear-gradient(135deg, rgba(224, 242, 254, 0.95) 0%, rgba(186, 230, 253, 0.95) 100%);
-  box-shadow: 0 24px 48px rgba(125, 211, 252, 0.25);
+  background: linear-gradient(135deg, rgba(37, 99, 235, 0.65) 0%, rgba(15, 118, 110, 0.55) 100%);
+  box-shadow: 0 24px 48px rgba(15, 118, 110, 0.3);
   transform: translateY(-4px);
 }
 
@@ -322,8 +325,8 @@
   width: clamp(260px, 40vw, 320px);
   border-radius: 36px;
   padding: 1.5rem 1.25rem;
-  background: linear-gradient(160deg, rgba(148, 163, 184, 0.1) 0%, rgba(148, 163, 184, 0.25) 100%);
-  box-shadow: 0 28px 64px rgba(15, 23, 42, 0.18);
+  background: linear-gradient(160deg, rgba(59, 130, 246, 0.08) 0%, rgba(15, 118, 110, 0.22) 100%);
+  box-shadow: 0 30px 70px rgba(2, 6, 23, 0.6);
   position: relative;
 }
 
@@ -334,22 +337,23 @@
   transform: translateX(-50%);
   width: 40%;
   height: 14px;
-  background: rgba(15, 23, 42, 0.35);
+  background: rgba(148, 163, 184, 0.35);
   border-radius: 0 0 12px 12px;
 }
 
 .focus-phone__screen {
-  background: linear-gradient(180deg, #f8fafc 0%, #ffffff 100%);
+  background: linear-gradient(180deg, #0f172a 0%, #1e293b 100%);
   border-radius: 24px;
   padding: 1.4rem 1rem;
   display: grid;
   gap: 1rem;
   min-height: 360px;
+  border: 1px solid rgba(148, 163, 184, 0.12);
 }
 
 .focus-phone__status {
   font-weight: 600;
-  color: rgba(15, 23, 42, 0.65);
+  color: rgba(148, 163, 184, 0.8);
   text-align: center;
   letter-spacing: 0.12em;
   text-transform: uppercase;
@@ -367,11 +371,11 @@
 .focus-phone__message {
   padding: 0.85rem 1rem;
   border-radius: 18px;
-  background: rgba(224, 242, 254, 0.85);
-  color: rgba(15, 23, 42, 0.85);
+  background: linear-gradient(135deg, rgba(59, 130, 246, 0.3) 0%, rgba(13, 148, 136, 0.3) 100%);
+  color: rgba(248, 250, 252, 0.92);
   font-size: 0.95rem;
   line-height: 1.4;
-  box-shadow: 0 16px 32px rgba(125, 211, 252, 0.25);
+  box-shadow: 0 18px 36px rgba(2, 6, 23, 0.55);
   animation: focus-pop 0.4s ease;
 }
 
@@ -452,7 +456,7 @@
   }
 
   .focus-hero__background {
-    background: linear-gradient(180deg, rgba(253, 246, 238, 1) 0%, rgba(233, 244, 251, 0.95) 65%, rgba(255, 255, 255, 0.95) 100%);
+    background: linear-gradient(180deg, rgba(15, 23, 42, 0.96) 0%, rgba(15, 23, 42, 0.88) 65%, rgba(2, 6, 23, 0.92) 100%);
   }
 
   .focus-hero__sun {

--- a/src/screens/Home.tsx
+++ b/src/screens/Home.tsx
@@ -31,8 +31,8 @@ const games: GameDefinition[] = [
     id: 'meditation',
     name: 'Meditation',
     description:
-      'Fordyb dig i guidede øvelser som Box Breathing og Yoga Meditation med levende lys. Find ro og fokus gennem vejrtrækning og nærvær.',
-    path: '/meditation',
+      'Hop direkte ind i Box Breathing øvelsen og lad åndedrættet finde en rolig rytme. Du kan altid udforske flere meditationer fra spillet.',
+    path: '/meditation/box-breathing',
     startLabel: 'Start meditation',
   },
   {

--- a/src/screens/LoginScreen.tsx
+++ b/src/screens/LoginScreen.tsx
@@ -4,9 +4,10 @@ import './LoginScreen.css'
 type LoginScreenProps = {
   onSkip: () => void
   onGoToRoutine: () => void
+  onGoToMeditation: () => void
 }
 
-export default function LoginScreen({ onSkip, onGoToRoutine }: LoginScreenProps) {
+export default function LoginScreen({ onSkip, onGoToRoutine, onGoToMeditation }: LoginScreenProps) {
   return (
     <div className="landing-wrapper">
       <div className="landing-overlay">
@@ -44,9 +45,13 @@ export default function LoginScreen({ onSkip, onGoToRoutine }: LoginScreenProps)
             >
               Gå til rutine
             </button>
-            <a className="landing-button landing-button--ghost" href="#learn-more">
-              Læs mere
-            </a>
+            <button
+              type="button"
+              className="landing-button landing-button--ghost"
+              onClick={onGoToMeditation}
+            >
+              Meditation
+            </button>
           </div>
         </main>
 


### PR DESCRIPTION
## Summary
- adjust the home menu layout for small screens with tighter spacing and full-width CTA buttons
- link the meditation entry directly to the box breathing experience and update the landing CTA
- refresh the focus routine screen with a darker, more subdued palette throughout

## Testing
- npm run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690e0103fe8c832faf5a70b0dcca141d)