### PR TITLE
Create three home page focus areas

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -127,6 +127,10 @@
   grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
 }
 
+.menu__grid--home {
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+}
+
 .game-page {
   display: flex;
   flex-direction: column;
@@ -210,6 +214,29 @@
   border: 1px solid rgba(99, 102, 241, 0.15);
 }
 
+.menu__card--home {
+  position: relative;
+  padding-block: clamp(1.5rem, 3.5vw, 2.2rem);
+  gap: clamp(0.75rem, 2vw, 1.1rem);
+}
+
+.menu__card-icon {
+  width: 3rem;
+  height: 3rem;
+  border-radius: 0.9rem;
+  display: grid;
+  place-items: center;
+  font-size: 1.5rem;
+  background: radial-gradient(circle at top left, rgba(96, 165, 250, 0.4), rgba(99, 102, 241, 0.2));
+  color: #1e293b;
+}
+
+.menu__card-content {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
 .menu__card h2 {
   margin: 0;
   font-size: clamp(1.3rem, 3vw, 1.6rem);
@@ -223,9 +250,24 @@
   line-height: 1.6;
 }
 
-.menu__card button,
-.menu__card a {
-  align-self: flex-start;
+.menu__card-links {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 0.4rem;
+  font-size: 0.95rem;
+}
+
+.menu__card-links a {
+  color: #2563eb;
+  text-decoration: none;
+  font-weight: 600;
+}
+
+.menu__card-links a:hover,
+.menu__card-links a:focus-visible {
+  text-decoration: underline;
 }
 
 .menu__primary-button {
@@ -244,6 +286,7 @@
   text-decoration: none;
   transition: transform 0.15s ease, box-shadow 0.15s ease, filter 0.15s ease;
   box-shadow: 0 0 0 rgba(79, 70, 229, 0);
+  align-self: flex-start;
 }
 
 .menu__primary-button:hover {
@@ -293,9 +336,17 @@
     grid-template-columns: minmax(0, 1fr);
   }
 
+  .menu__grid--home {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
   .menu__card {
     padding: clamp(1rem, 6vw, 1.5rem);
     gap: 0.85rem;
+  }
+
+  .menu__card--home {
+    gap: clamp(0.6rem, 4vw, 1rem);
   }
 
   .menu__card h2 {
@@ -305,6 +356,16 @@
   .menu__card p {
     font-size: 0.95rem;
     line-height: 1.55;
+  }
+
+  .menu__card-icon {
+    width: 2.75rem;
+    height: 2.75rem;
+    font-size: 1.35rem;
+  }
+
+  .menu__card-links {
+    font-size: 0.9rem;
   }
 
   .menu__primary-button {
@@ -359,12 +420,21 @@
     box-shadow: inset 0 1px 0 rgba(148, 163, 184, 0.15);
   }
 
+  .menu__card-icon {
+    background: radial-gradient(circle at top left, rgba(96, 165, 250, 0.35), rgba(129, 140, 248, 0.25));
+    color: #e2e8f0;
+  }
+
   .menu__card h2 {
     color: #e2e8f0;
   }
 
   .menu__card p {
     color: #cbd5f5;
+  }
+
+  .menu__card-links a {
+    color: #a5b4fc;
   }
 
   .menu__card button,

--- a/src/screens/Home.tsx
+++ b/src/screens/Home.tsx
@@ -1,64 +1,55 @@
 import { Link } from 'react-router-dom'
 import BrandLogo from '../components/BrandLogo'
 
-interface GameDefinition {
+type SectionLink = {
+  to: string
+  label: string
+}
+
+type HomeSection = {
   id: string
-  name: string
+  title: string
   description: string
-  path: string
-  startLabel: string
+  cta: SectionLink
+  icon: string
+  links?: SectionLink[]
 }
 
-const puzzleBloxGame: GameDefinition = {
-  id: 'puzzle-blox',
-  name: 'Puzzle Blox',
-  description:
-    'Fjern de overskydende klodser i hovedgridden, lad dem falde med tyngdekraften og genskab målfiguren niveau for niveau.',
-  path: '/puzzle-blox',
-  startLabel: 'Start Puzzle Blox',
-}
-
-const games: GameDefinition[] = [
+const sections: HomeSection[] = [
   {
-    id: 'reaction-test',
-    name: 'Reaktionstest',
+    id: 'cognitive-games',
+    title: 'Cognitive Games',
     description:
-      'Hvor hurtigt kan du reagere? Klik, så snart skærmen skifter farve, og se dine bedste tider.',
-    path: '/reaction-test',
-    startLabel: 'Start reaktionstest',
+      'Boost hukommelsen og koncentrationen med hurtige, videnskabeligt inspirerede mini-udfordringer.',
+    cta: { to: '/memory', label: 'Udforsk spil' },
+    icon: '🧠',
+    links: [
+      { to: '/reaction-test', label: 'Reaktionstest' },
+      { to: '/sorting', label: 'Sorteringsspillet' },
+      { to: '/odd-one-out', label: 'Odd One Out' },
+      { to: '/puzzle-blox', label: 'Puzzle Blox' },
+    ],
   },
   {
-    id: 'meditation',
-    name: 'Meditation',
+    id: 'meditation-breathing',
+    title: 'Meditation & Breathing',
     description:
-      'Hop direkte ind i Box Breathing øvelsen og lad åndedrættet finde en rolig rytme. Du kan altid udforske flere meditationer fra spillet.',
-    path: '/meditation/box-breathing',
-    startLabel: 'Start meditation',
+      'Find ro og rytme i åndedrættet med guidede meditationer og visuelle vejrtrækningsøvelser.',
+    cta: { to: '/meditation/box-breathing', label: 'Start meditation' },
+    icon: '🧘',
+    links: [
+      { to: '/meditation/box-breathing', label: 'Box Breathing' },
+      { to: '/meditation/yoga-candle', label: 'Candle Breathing' },
+    ],
   },
   {
-    id: 'memory',
-    name: 'Memory',
+    id: 'routine-builder',
+    title: 'Rutiner & Vaner',
     description:
-      'Vend to kort ad gangen og find alle par hurtigst muligt. Flere sværhedsgrader og highscores.',
-    path: '/memory',
-    startLabel: 'Start memory',
+      'Byg holdbare vaner med daglige fokusområder og inspiration til dine egne rutiner.',
+    cta: { to: '/rutines', label: 'Åbn rutinebygger' },
+    icon: '🗓️',
   },
-  {
-    id: 'sorting',
-    name: 'Sorteringsspillet',
-    description:
-      'Sortér figurerne til venstre eller højre efter reglerne. Brug piletasterne, hold tempoet og jag din bedste score.',
-    path: '/sorting',
-    startLabel: 'Start sorteringsspil',
-  },
-  {
-    id: 'odd-one-out',
-    name: 'Odd One Out',
-    description: 'Find figuren der skiller sig ud fra mængden på tid.',
-    path: '/odd-one-out',
-    startLabel: 'Start Odd One Out',
-  },
-  puzzleBloxGame,
 ]
 
 export default function Home() {
@@ -73,16 +64,30 @@ export default function Home() {
           wordmarkText="Fokus 2.0"
           style={{ marginBottom: '0.5rem' }}
         />
-        <p>Vælg et spil for at komme i gang.</p>
+        <p>Everything you need for mental clarity.</p>
       </header>
 
-      <section className="menu__grid">
-        {games.map((game) => (
-          <article key={game.id} className="menu__card">
-            <h2>{game.name}</h2>
-            <p>{game.description}</p>
-            <Link to={game.path} className="menu__primary-button">
-              {game.startLabel}
+      <section className="menu__grid menu__grid--home">
+        {sections.map((section) => (
+          <article key={section.id} className="menu__card menu__card--home">
+            <span aria-hidden="true" className="menu__card-icon">
+              {section.icon}
+            </span>
+            <div className="menu__card-content">
+              <h2>{section.title}</h2>
+              <p>{section.description}</p>
+            </div>
+            {section.links && (
+              <ul className="menu__card-links">
+                {section.links.map((link) => (
+                  <li key={link.to}>
+                    <Link to={link.to}>{link.label}</Link>
+                  </li>
+                ))}
+              </ul>
+            )}
+            <Link to={section.cta.to} className="menu__primary-button">
+              {section.cta.label}
             </Link>
           </article>
         ))}


### PR DESCRIPTION
## Summary
- redesign the home screen to highlight three focus areas: cognitive games, meditation, and routine building
- add contextual quick links and clear calls-to-action for each focus area
- extend shared styles to support the new card layout, icons, and dark mode accents

## Testing
- npm run build *(fails: missing `vite/client` types because dependencies could not be installed without `patch-package`)*
- npm install *(fails: dependency install requires `patch-package`, which is not available in the environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690e697918f4832f83602785c70a60f7)