### PR TITLE
Improve routine habit guidance and overview mobile behavior

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -66,6 +66,19 @@
   overflow-y: auto;
   overscroll-behavior: contain;
   scrollbar-gutter: stable;
+  -webkit-overflow-scrolling: touch;
+}
+
+.menu--overview {
+  touch-action: pan-y;
+}
+
+.menu--overview .menu__card {
+  min-width: 0;
+}
+
+.menu--overview .menu__primary-button {
+  max-width: 100%;
 }
 
 .menu__header {
@@ -345,6 +358,11 @@
     box-shadow: 0 20px 45px rgba(15, 23, 42, 0.18);
   }
 
+  .menu--overview {
+    overflow: visible;
+    touch-action: auto;
+  }
+
   .menu__header {
     text-align: left;
     margin-bottom: clamp(1.25rem, 6vw, 1.75rem);
@@ -400,6 +418,10 @@
   .menu__primary-button {
     width: 100%;
     justify-content: center;
+  }
+
+  .menu--overview .menu__primary-button {
+    align-self: stretch;
   }
 }
 

--- a/src/screens/FocusRoutineScreen.css
+++ b/src/screens/FocusRoutineScreen.css
@@ -104,6 +104,336 @@
   box-shadow: 0 36px 72px rgba(30, 64, 175, 0.45);
 }
 
+.focus-daily {
+  padding: 0 clamp(1.5rem, 8vw, 6rem) clamp(3rem, 10vw, 4.5rem);
+  display: grid;
+  gap: clamp(1.5rem, 5vw, 2.5rem);
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  align-items: stretch;
+}
+
+.focus-daily__cue,
+.focus-quick-start {
+  position: relative;
+  border-radius: 28px;
+  padding: clamp(1.75rem, 4vw, 2.3rem);
+  display: grid;
+  gap: 1rem;
+  backdrop-filter: blur(12px);
+  box-shadow: 0 26px 58px rgba(2, 6, 23, 0.45);
+}
+
+.focus-daily__cue {
+  background: linear-gradient(160deg, rgba(15, 23, 42, 0.78), rgba(30, 41, 59, 0.9));
+  border: 1px solid rgba(148, 163, 184, 0.2);
+}
+
+.focus-quick-start {
+  background: linear-gradient(150deg, rgba(37, 99, 235, 0.38), rgba(15, 118, 110, 0.4));
+  border: 1px solid rgba(56, 189, 248, 0.35);
+  overflow: hidden;
+}
+
+.focus-daily__eyebrow,
+.focus-quick-start__eyebrow {
+  font-size: 0.85rem;
+  letter-spacing: 0.24em;
+  text-transform: uppercase;
+  color: rgba(148, 163, 184, 0.75);
+}
+
+.focus-daily__cue h3,
+.focus-quick-start h3 {
+  margin: 0;
+  font-size: clamp(1.4rem, 3.5vw, 1.8rem);
+  line-height: 1.35;
+  color: #f8fafc;
+}
+
+.focus-daily__cue p,
+.focus-quick-start p {
+  margin: 0;
+  line-height: 1.6;
+}
+
+.focus-daily__reminder {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 0.9rem;
+  align-items: center;
+  padding: 1rem 1.25rem;
+  border-radius: 18px;
+  background: rgba(30, 41, 59, 0.65);
+  border: 1px solid rgba(148, 163, 184, 0.25);
+}
+
+.focus-daily__icon {
+  font-size: 2rem;
+}
+
+.focus-daily__reminder-time {
+  margin: 0;
+  font-weight: 600;
+  color: rgba(148, 163, 184, 0.85);
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  font-size: 0.8rem;
+}
+
+.focus-daily__reminder-text {
+  margin: 0;
+  color: rgba(226, 232, 240, 0.85);
+  font-size: 0.95rem;
+}
+
+.focus-quick-start__memory {
+  color: rgba(226, 232, 240, 0.88);
+}
+
+.focus-quick-start__actions {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.focus-quick-start__button {
+  border: none;
+  border-radius: 999px;
+  padding: 0.95rem 1.75rem;
+  font-size: 1rem;
+  font-weight: 600;
+  color: #f8fafc;
+  cursor: pointer;
+  background: linear-gradient(135deg, rgba(15, 118, 110, 0.95), rgba(37, 99, 235, 0.95));
+  box-shadow: 0 28px 56px rgba(15, 118, 110, 0.35);
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.focus-quick-start__button:hover,
+.focus-quick-start__button:focus-visible {
+  transform: translateY(-2px);
+  box-shadow: 0 32px 64px rgba(15, 118, 110, 0.4);
+}
+
+.focus-quick-start__button:disabled {
+  cursor: not-allowed;
+  opacity: 0.75;
+  box-shadow: none;
+}
+
+.focus-quick-start__status {
+  color: rgba(226, 232, 240, 0.9);
+  font-size: 0.95rem;
+}
+
+.focus-quick-start__complete {
+  border: 1px solid rgba(226, 232, 240, 0.4);
+  border-radius: 999px;
+  padding: 0.85rem 1.5rem;
+  background: rgba(15, 23, 42, 0.25);
+  color: #f8fafc;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.2s ease, border-color 0.2s ease;
+}
+
+.focus-quick-start__complete:hover,
+.focus-quick-start__complete:focus-visible {
+  background: rgba(15, 23, 42, 0.4);
+  border-color: rgba(226, 232, 240, 0.6);
+}
+
+.focus-quick-start__hint {
+  font-size: 0.9rem;
+  color: rgba(226, 232, 240, 0.82);
+}
+
+.focus-quick-start__options {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.6rem;
+}
+
+.focus-quick-start__chip {
+  border: 1px solid rgba(226, 232, 240, 0.3);
+  border-radius: 999px;
+  padding: 0.55rem 1.1rem;
+  background: rgba(15, 23, 42, 0.2);
+  color: #f8fafc;
+  display: grid;
+  gap: 0.15rem;
+  font-size: 0.95rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: transform 0.2s ease, border-color 0.2s ease, background 0.2s ease;
+}
+
+.focus-quick-start__chip small {
+  font-size: 0.7rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: rgba(148, 163, 184, 0.85);
+}
+
+.focus-quick-start__chip.is-active {
+  background: rgba(15, 23, 42, 0.5);
+  border-color: rgba(56, 189, 248, 0.65);
+  transform: translateY(-2px);
+  box-shadow: 0 16px 32px rgba(15, 23, 42, 0.45);
+}
+
+.focus-quick-start__chip.is-mini::after {
+  content: 'Mini';
+  font-size: 0.65rem;
+  text-transform: uppercase;
+  letter-spacing: 0.2em;
+  color: rgba(148, 163, 184, 0.75);
+  justify-self: start;
+}
+
+.focus-celebration {
+  margin-top: 1.1rem;
+  padding: 1rem 1.3rem;
+  border-radius: 20px;
+  background: linear-gradient(135deg, rgba(56, 189, 248, 0.3), rgba(99, 102, 241, 0.3));
+  color: rgba(248, 250, 252, 0.95);
+  text-align: center;
+  display: grid;
+  gap: 0.45rem;
+  place-items: center;
+  animation: focus-fade-in 0.35s ease, focus-celebration-glow 2.4s ease infinite alternate;
+}
+
+.focus-quick-start__reward-label {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.24em;
+  color: rgba(226, 232, 240, 0.75);
+}
+
+.focus-celebration__icon {
+  font-size: 2.4rem;
+  animation: focus-sparkle 1.6s ease infinite;
+}
+
+.focus-progress {
+  padding: clamp(3rem, 10vw, 5rem) clamp(1.5rem, 8vw, 6rem);
+  display: grid;
+  gap: clamp(2rem, 6vw, 3rem);
+  background: linear-gradient(180deg, rgba(15, 23, 42, 0.82) 0%, rgba(15, 23, 42, 0.92) 100%);
+}
+
+.focus-progress__grid {
+  display: grid;
+  gap: clamp(1.5rem, 5vw, 2.5rem);
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+}
+
+.focus-progress__card {
+  background: linear-gradient(160deg, rgba(30, 41, 59, 0.85), rgba(15, 23, 42, 0.95));
+  border-radius: 28px;
+  padding: clamp(1.75rem, 4vw, 2.3rem);
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  display: grid;
+  gap: 1rem;
+  box-shadow: 0 24px 60px rgba(2, 6, 23, 0.5);
+}
+
+.focus-progress__card h3 {
+  margin: 0;
+  font-size: clamp(1.4rem, 3.5vw, 1.8rem);
+}
+
+.focus-progress__card p {
+  margin: 0;
+  color: rgba(226, 232, 240, 0.85);
+  line-height: 1.6;
+}
+
+.focus-progress__bar {
+  position: relative;
+  height: 12px;
+  border-radius: 999px;
+  background: rgba(30, 41, 59, 0.6);
+  overflow: hidden;
+}
+
+.focus-progress__bar span {
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  background: linear-gradient(135deg, rgba(37, 99, 235, 0.8), rgba(15, 118, 110, 0.9));
+  transition: width 0.3s ease;
+}
+
+.focus-progress__goal {
+  font-size: 0.8rem;
+  color: rgba(148, 163, 184, 0.75);
+  text-transform: uppercase;
+  letter-spacing: 0.16em;
+}
+
+.focus-progress__week {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 0.85rem;
+  grid-template-columns: repeat(7, minmax(0, 1fr));
+}
+
+.focus-progress__day {
+  padding: 0.9rem;
+  border-radius: 18px;
+  background: rgba(15, 23, 42, 0.55);
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  display: grid;
+  gap: 0.4rem;
+  justify-items: center;
+  color: rgba(226, 232, 240, 0.8);
+  font-size: 0.9rem;
+}
+
+.focus-progress__day-label {
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.focus-progress__day-status {
+  font-size: 1.2rem;
+}
+
+.focus-progress__day.is-complete {
+  background: linear-gradient(140deg, rgba(37, 99, 235, 0.55), rgba(15, 118, 110, 0.55));
+  border-color: rgba(37, 99, 235, 0.6);
+  box-shadow: 0 18px 36px rgba(15, 118, 110, 0.35);
+  color: #f8fafc;
+}
+
+@keyframes focus-celebration-glow {
+  from {
+    box-shadow: 0 18px 40px rgba(37, 99, 235, 0.4);
+  }
+  to {
+    box-shadow: 0 26px 60px rgba(56, 189, 248, 0.5);
+  }
+}
+
+@keyframes focus-sparkle {
+  0% {
+    transform: scale(0.95) rotate(-4deg);
+    filter: drop-shadow(0 0 0 rgba(56, 189, 248, 0.3));
+  }
+  50% {
+    transform: scale(1.05) rotate(4deg);
+    filter: drop-shadow(0 8px 18px rgba(56, 189, 248, 0.45));
+  }
+  100% {
+    transform: scale(0.98) rotate(-2deg);
+    filter: drop-shadow(0 0 0 rgba(56, 189, 248, 0.3));
+  }
+}
+
 .focus-section-header {
   max-width: min(760px, 90vw);
   margin: 0 auto;
@@ -448,6 +778,10 @@
   .focus-timeline::before {
     display: none;
   }
+
+  .focus-progress__week {
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+  }
 }
 
 @media (max-width: 720px) {
@@ -465,6 +799,15 @@
 
   .focus-hero__ocean {
     height: clamp(200px, 40vw, 280px);
+  }
+
+  .focus-daily {
+    grid-template-columns: 1fr;
+    padding-inline: clamp(1.1rem, 8vw, 2rem);
+  }
+
+  .focus-progress {
+    padding-inline: clamp(1.1rem, 8vw, 2rem);
   }
 }
 
@@ -485,5 +828,18 @@
   .focus-phone {
     width: 100%;
     max-width: 320px;
+  }
+
+  .focus-quick-start__options {
+    flex-direction: column;
+  }
+
+  .focus-quick-start__chip {
+    width: 100%;
+    text-align: left;
+  }
+
+  .focus-progress__week {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
   }
 }

--- a/src/screens/FocusRoutineScreen.tsx
+++ b/src/screens/FocusRoutineScreen.tsx
@@ -1,4 +1,4 @@
-import { useRef, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import BrandLogo from '../components/BrandLogo'
 import './FocusRoutineScreen.css'
 
@@ -72,14 +72,249 @@ const notificationsByPeriod: Record<RoutinePhase['id'], string[]> = {
   ],
 }
 
+type QuickStartOption = {
+  id: string
+  label: string
+  description: string
+  duration: string
+  isMini?: boolean
+}
+
+type WeeklyDay = {
+  label: string
+  completed: boolean
+}
+
+type StoredProgress = {
+  streakCount: number
+  lastCompletionDate: string | null
+  weekStart: string
+  weeklyProgress: WeeklyDay[]
+}
+
+const quickStartOptions: QuickStartOption[] = [
+  {
+    id: 'breath-mini',
+    label: '1 minut vejrtrækning',
+    description: 'En mikro-pause du kan tage mellem møder.',
+    duration: '1 min',
+    isMini: true,
+  },
+  {
+    id: 'breath-box',
+    label: '5 minutters box breathing',
+    description: 'Din seneste favorit til at skabe ro.',
+    duration: '5 min',
+  },
+  {
+    id: 'movement-reset',
+    label: '3 minutters stræk',
+    description: 'Giv kroppen et lille boost midt på dagen.',
+    duration: '3 min',
+    isMini: true,
+  },
+]
+
+const weekdayLabels = ['Man', 'Tir', 'Ons', 'Tor', 'Fre', 'Lør', 'Søn']
+
+const createEmptyWeek = (): WeeklyDay[] => weekdayLabels.map((label) => ({ label, completed: false }))
+
+const getWeekStart = (date: Date) => {
+  const current = new Date(date)
+  const day = current.getDay()
+  const diff = day === 0 ? -6 : 1 - day
+  current.setDate(current.getDate() + diff)
+  current.setHours(0, 0, 0, 0)
+  return current.toISOString().slice(0, 10)
+}
+
+const getWeekdayIndex = (date: Date) => {
+  const day = date.getDay()
+  return (day + 6) % 7
+}
+
+const getIsoDate = (date: Date) => {
+  const clone = new Date(date)
+  clone.setHours(0, 0, 0, 0)
+  return clone.toISOString().slice(0, 10)
+}
+
+const QUICK_START_STORAGE_KEY = 'focus.quick-start-preference'
+const PROGRESS_STORAGE_KEY = 'focus.routine-progress'
+const WEEKLY_GOAL = 5
+const MS_PER_DAY = 86_400_000
+
+const dailyFocus = {
+  title: 'Dagens fokus: 5 min vejrtrækning',
+  description: 'Et roligt åndedræts-anker, der hjælper dig med at lande og starte dagen bevidst.',
+  icon: '🌬️',
+  reminderTime: '09:00',
+  reminderText: 'Påmindelsen dukker op hver dag kl. 09:00. Tag fem rolige, dybe åndedrag.',
+}
+
 export default function FocusRoutineScreen() {
   const routineSectionRef = useRef<HTMLElement | null>(null)
+  const celebrationTimeoutRef = useRef<number | null>(null)
+  const storedProgressRef = useRef<StoredProgress | null>(null)
   const [expandedPhase, setExpandedPhase] = useState<RoutinePhase['id'] | null>('morning')
   const [activePeriod, setActivePeriod] = useState<RoutinePhase['id']>('morning')
+  const [isQuickStartActive, setIsQuickStartActive] = useState(false)
+
+  if (storedProgressRef.current === null && typeof window !== 'undefined') {
+    const raw = window.localStorage.getItem(PROGRESS_STORAGE_KEY)
+    if (raw) {
+      try {
+        storedProgressRef.current = JSON.parse(raw) as StoredProgress
+      } catch (error) {
+        storedProgressRef.current = null
+      }
+    }
+  }
+
+  const today = new Date()
+  const todayIso = getIsoDate(today)
+  const currentWeekStart = getWeekStart(today)
+
+  const [selectedQuickStartId, setSelectedQuickStartId] = useState(() => {
+    if (typeof window === 'undefined') {
+      return quickStartOptions[0].id
+    }
+
+    const storedPreference = window.localStorage.getItem(QUICK_START_STORAGE_KEY)
+    const hasMatch = quickStartOptions.some((option) => option.id === storedPreference)
+    return hasMatch && storedPreference ? storedPreference : quickStartOptions[0].id
+  })
+
+  const [streakCount, setStreakCount] = useState(() => storedProgressRef.current?.streakCount ?? 2)
+  const [lastCompletionDate, setLastCompletionDate] = useState<string | null>(
+    storedProgressRef.current?.lastCompletionDate ?? null,
+  )
+  const [weekStart, setWeekStart] = useState(() => storedProgressRef.current?.weekStart ?? currentWeekStart)
+  const [weeklyProgress, setWeeklyProgress] = useState<WeeklyDay[]>(() => {
+    const stored = storedProgressRef.current
+    if (stored?.weekStart === currentWeekStart && Array.isArray(stored.weeklyProgress)) {
+      const template = createEmptyWeek()
+      return template.map((day, index) => ({
+        ...day,
+        completed: Boolean(stored.weeklyProgress[index]?.completed),
+      }))
+    }
+    return createEmptyWeek()
+  })
+  const [isCelebrating, setIsCelebrating] = useState(false)
 
   const handleScrollToRoutine = () => {
     routineSectionRef.current?.scrollIntoView({ behavior: 'smooth' })
   }
+
+  const selectedQuickStart =
+    quickStartOptions.find((option) => option.id === selectedQuickStartId) ?? quickStartOptions[0]
+  const completedThisWeek = weeklyProgress.filter((day) => day.completed).length
+  const progressValue = Math.min(completedThisWeek, WEEKLY_GOAL)
+  const progressPercent = Math.min(100, (progressValue / WEEKLY_GOAL) * 100)
+  const hasCompletedToday = lastCompletionDate === todayIso
+  const quickStartButtonLabel = hasCompletedToday
+    ? 'Rutinen er fuldført i dag'
+    : isQuickStartActive
+      ? 'Rutinen er i gang...'
+      : `Start ${selectedQuickStart.label}`
+  const quickStartStatusMessage = hasCompletedToday
+    ? 'Du har allerede markeret dagens rutine. Gentag gerne for ekstra ro.'
+    : isQuickStartActive
+      ? 'Din mikro-rutine er startet – find ro i åndedrættet.'
+      : 'Tryk på knappen for at komme i gang med det samme.'
+
+  const handleSelectQuickStart = (optionId: string) => {
+    setSelectedQuickStartId(optionId)
+    if (hasCompletedToday) {
+      setIsQuickStartActive(false)
+    }
+  }
+
+  const handleStartQuickStart = () => {
+    setIsQuickStartActive(true)
+    setIsCelebrating(false)
+    if (celebrationTimeoutRef.current) {
+      window.clearTimeout(celebrationTimeoutRef.current)
+    }
+  }
+
+  const handleCompleteRoutine = () => {
+    const isoToday = todayIso
+
+    let nextStreak = 1
+    if (lastCompletionDate) {
+      const last = new Date(lastCompletionDate)
+      const lastIso = getIsoDate(last)
+      const diff = (new Date(isoToday).getTime() - new Date(lastIso).getTime()) / MS_PER_DAY
+      if (diff === 0) {
+        nextStreak = streakCount
+      } else if (diff === 1) {
+        nextStreak = streakCount + 1
+      } else {
+        nextStreak = 1
+      }
+    }
+
+    const newWeekStart = getWeekStart(new Date())
+    const dayIndex = getWeekdayIndex(new Date())
+
+    setWeeklyProgress((previous) => {
+      const base = newWeekStart === weekStart ? previous : createEmptyWeek()
+      const updated = base.map((day, index) => ({
+        ...day,
+        completed: index === dayIndex ? true : day.completed,
+      }))
+      if (newWeekStart !== weekStart) {
+        setWeekStart(newWeekStart)
+      }
+      return updated
+    })
+
+    setStreakCount(nextStreak)
+    setLastCompletionDate(isoToday)
+    setIsQuickStartActive(false)
+    setIsCelebrating(true)
+
+    if (celebrationTimeoutRef.current) {
+      window.clearTimeout(celebrationTimeoutRef.current)
+    }
+
+    celebrationTimeoutRef.current = window.setTimeout(() => {
+      setIsCelebrating(false)
+    }, 2600)
+  }
+
+  useEffect(() => {
+    if (typeof window === 'undefined') {
+      return
+    }
+
+    window.localStorage.setItem(QUICK_START_STORAGE_KEY, selectedQuickStartId)
+  }, [selectedQuickStartId])
+
+  useEffect(() => {
+    if (typeof window === 'undefined') {
+      return
+    }
+
+    const payload: StoredProgress = {
+      streakCount,
+      lastCompletionDate,
+      weekStart,
+      weeklyProgress,
+    }
+
+    window.localStorage.setItem(PROGRESS_STORAGE_KEY, JSON.stringify(payload))
+  }, [streakCount, lastCompletionDate, weekStart, weeklyProgress])
+
+  useEffect(() => {
+    return () => {
+      if (celebrationTimeoutRef.current) {
+        window.clearTimeout(celebrationTimeoutRef.current)
+      }
+    }
+  }, [])
 
   return (
     <div className="focus-page">
@@ -103,6 +338,127 @@ export default function FocusRoutineScreen() {
           </button>
         </div>
       </header>
+
+      <section className="focus-daily" aria-labelledby="daily-focus-heading">
+        <h2 id="daily-focus-heading" className="sr-only">
+          Dagens vane og hurtig start
+        </h2>
+
+        <article className="focus-daily__cue" aria-labelledby="daily-cue-title">
+          <span className="focus-daily__eyebrow">Gør det synligt</span>
+          <h3 id="daily-cue-title">{dailyFocus.title}</h3>
+          <p>{dailyFocus.description}</p>
+          <div className="focus-daily__reminder" role="status" aria-live="polite">
+            <span className="focus-daily__icon" aria-hidden="true">
+              {dailyFocus.icon}
+            </span>
+            <div>
+              <p className="focus-daily__reminder-time">Påmindelse kl. {dailyFocus.reminderTime}</p>
+              <p className="focus-daily__reminder-text">{dailyFocus.reminderText}</p>
+            </div>
+          </div>
+        </article>
+
+        <article className="focus-quick-start" aria-labelledby="quick-start-heading">
+          <span className="focus-quick-start__eyebrow">Gør det nemt</span>
+          <h3 id="quick-start-heading">Start din rutine med ét tryk</h3>
+          <p className="focus-quick-start__memory">Appen husker: {selectedQuickStart.description}</p>
+
+          <div className="focus-quick-start__actions">
+            <button
+              type="button"
+              className="focus-quick-start__button"
+              onClick={handleStartQuickStart}
+              disabled={isQuickStartActive && !hasCompletedToday}
+            >
+              {quickStartButtonLabel}
+            </button>
+            <p className="focus-quick-start__status">{quickStartStatusMessage}</p>
+
+            {isQuickStartActive && !hasCompletedToday && (
+              <button type="button" className="focus-quick-start__complete" onClick={handleCompleteRoutine}>
+                Markér rutinen som fuldført
+              </button>
+            )}
+          </div>
+
+          <p className="focus-quick-start__hint">Start småt, men konsekvent – vælg en mini-version når tiden er knap.</p>
+          <div className="focus-quick-start__options">
+            {quickStartOptions.map((option) => (
+              <button
+                key={option.id}
+                type="button"
+                className={`focus-quick-start__chip ${selectedQuickStartId === option.id ? 'is-active' : ''} ${
+                  option.isMini ? 'is-mini' : ''
+                }`}
+                onClick={() => handleSelectQuickStart(option.id)}
+                aria-pressed={selectedQuickStartId === option.id}
+              >
+                <span>{option.label}</span>
+                <small>{option.duration}</small>
+              </button>
+            ))}
+          </div>
+
+          {isCelebrating && (
+            <div className="focus-celebration" role="status" aria-live="assertive">
+              <span className="focus-quick-start__reward-label">Gør det tilfredsstillende</span>
+              <span className="focus-celebration__icon" aria-hidden="true">
+                🌱
+              </span>
+              <p>Stærkt gået! Din vane vokser – kom tilbage i morgen for at bygge videre.</p>
+            </div>
+          )}
+        </article>
+      </section>
+
+      <section className="focus-progress" aria-labelledby="progress-heading">
+        <header className="focus-section-header">
+          <span className="focus-section-eyebrow">📈 Gør det konkret og målbart</span>
+          <h2 id="progress-heading">Hold øje med din udvikling</h2>
+          <p>
+            {progressValue}/{WEEKLY_GOAL} rutiner gennemført denne uge. Hver lille handling tæller mod en stærk vane.
+          </p>
+        </header>
+
+        <div className="focus-progress__grid">
+          <article className="focus-progress__card focus-progress__card--streak">
+            <h3>{streakCount} dage i træk</h3>
+            <p>
+              Bliv ved! Når du følger rytmen dag efter dag, bygger du en vane, der holder.
+            </p>
+            <div
+              className="focus-progress__bar"
+              role="progressbar"
+              aria-valuemin={0}
+              aria-valuemax={WEEKLY_GOAL}
+              aria-valuenow={progressValue}
+              aria-label="Ugentlig fremdrift"
+            >
+              <span style={{ width: `${progressPercent}%` }} />
+            </div>
+            <small className="focus-progress__goal">Mål: {WEEKLY_GOAL} rutiner om ugen</small>
+          </article>
+
+          <article className="focus-progress__card focus-progress__card--week" aria-label="Ugens rutineoversigt">
+            <p>Marker dagene, efterhånden som du gennemfører rutinen. En tydelig rytme holder motivationen høj.</p>
+            <ul className="focus-progress__week">
+              {weeklyProgress.map((day, index) => (
+                <li
+                  key={`${day.label}-${index}`}
+                  className={`focus-progress__day ${day.completed ? 'is-complete' : ''}`}
+                  aria-label={`${day.label}: ${day.completed ? 'Gennemført' : 'Ikke gennemført'}`}
+                >
+                  <span className="focus-progress__day-label">{day.label}</span>
+                  <span className="focus-progress__day-status" aria-hidden="true">
+                    {day.completed ? '●' : '○'}
+                  </span>
+                </li>
+              ))}
+            </ul>
+          </article>
+        </div>
+      </section>
 
       <section className="focus-routine" ref={routineSectionRef} id="rutine">
         <header className="focus-section-header">

--- a/src/screens/OverviewScreen.tsx
+++ b/src/screens/OverviewScreen.tsx
@@ -54,7 +54,7 @@ const sections: OverviewSection[] = [
 
 export default function OverviewScreen() {
   return (
-    <div className="menu">
+    <div className="menu menu--overview">
       <header className="menu__header">
         <BrandLogo
           as="h1"


### PR DESCRIPTION
## Summary
- allow the overview screen container to scroll naturally on mobile and keep primary buttons within the cards
- introduce daily focus cues, a one-tap quick start, celebratory feedback, and streak tracking on the routine page to reflect Atomic Habits guidance
- add styling for the new routine overview sections and celebration visuals

## Testing
- npm run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690f85cdbe10832fa6583f6288e17d06)