### PR TITLE
Redesign focus landing screen with calm visuals

### DIFF
--- a/src/screens/FocusRoutineScreen.css
+++ b/src/screens/FocusRoutineScreen.css
@@ -1,6 +1,6 @@
 .focus-page {
-  background: linear-gradient(160deg, #0f172a 0%, #1f2937 45%, #020617 100%);
-  color: #e2e8f0;
+  background: linear-gradient(180deg, #f5f8fb 0%, #fdfaf4 100%);
+  color: #0f172a;
   min-height: 100vh;
   display: flex;
   flex-direction: column;
@@ -9,99 +9,232 @@
 .focus-hero {
   position: relative;
   overflow: hidden;
-  padding: clamp(4rem, 10vw, 6rem) clamp(1.5rem, 8vw, 6rem);
-  display: grid;
+  padding: clamp(3.5rem, 9vw, 6rem) clamp(1.5rem, 8vw, 6rem);
+  display: flex;
+  flex-direction: column;
   gap: clamp(2rem, 6vw, 4rem);
-  align-items: center;
 }
 
 .focus-hero__background {
   position: absolute;
   inset: 0;
-  background: linear-gradient(180deg, rgba(15, 23, 42, 0.95) 0%, rgba(15, 23, 42, 0.85) 65%, rgba(2, 6, 23, 0.9) 100%);
-  overflow: hidden;
+  background: radial-gradient(circle at top left, rgba(209, 225, 240, 0.4), transparent 55%),
+    radial-gradient(circle at 85% 25%, rgba(251, 227, 208, 0.5), transparent 60%),
+    linear-gradient(180deg, rgba(244, 248, 252, 0.95) 0%, rgba(250, 246, 239, 0.9) 100%);
   z-index: 0;
 }
 
-.focus-hero__sun {
+.focus-hero__background::after {
+  content: '';
   position: absolute;
-  width: clamp(320px, 40vw, 460px);
-  aspect-ratio: 1 / 1;
-  border-radius: 50%;
-  background: radial-gradient(circle at 50% 50%, rgba(248, 250, 252, 0.7) 0%, rgba(254, 215, 102, 0.4) 45%, rgba(253, 186, 116, 0.25) 70%, rgba(253, 186, 116, 0) 100%);
-  bottom: 12%;
-  left: 50%;
-  transform: translateX(-50%);
-  animation: focus-sunrise 12s ease-in-out infinite alternate;
-}
-
-.focus-hero__horizon {
-  position: absolute;
-  bottom: 22%;
-  left: -10%;
-  width: 120%;
-  height: clamp(140px, 18vw, 200px);
-  background: linear-gradient(180deg, rgba(59, 130, 246, 0) 0%, rgba(148, 163, 184, 0.35) 100%);
-  filter: blur(18px);
-}
-
-.focus-hero__ocean {
-  position: absolute;
-  bottom: 0;
-  left: 0;
-  width: 100%;
-  height: clamp(220px, 30vw, 300px);
-  background: linear-gradient(180deg, rgba(15, 118, 110, 0.45) 0%, rgba(14, 116, 144, 0.5) 50%, rgba(8, 47, 73, 0.6) 100%);
-  transform: translateY(24px);
+  inset: 0;
+  background-image: radial-gradient(rgba(172, 190, 211, 0.28) 1px, transparent 1px);
+  background-size: 52px 52px;
+  opacity: 0.4;
 }
 
 .focus-hero__content {
   position: relative;
   z-index: 1;
-  max-width: min(680px, 90vw);
+  display: grid;
+  gap: clamp(2rem, 4vw, 3rem);
+}
+
+.focus-hero__topbar {
   display: flex;
-  flex-direction: column;
-  gap: 1.75rem;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.focus-hero__mode-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.55rem;
+  border-radius: 999px;
+  border: 1px solid rgba(15, 118, 110, 0.18);
+  background: rgba(255, 255, 255, 0.75);
+  padding: 0.55rem 1.2rem;
+  font-size: 0.95rem;
+  font-weight: 600;
+  color: #0f172a;
+  box-shadow: 0 12px 24px rgba(15, 118, 110, 0.08);
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.focus-hero__mode-toggle:hover,
+.focus-hero__mode-toggle:focus-visible {
+  transform: translateY(-2px);
+  box-shadow: 0 16px 32px rgba(15, 118, 110, 0.12);
+}
+
+.focus-hero__mode-icon {
+  font-size: 1.1rem;
+}
+
+.focus-hero__body {
+  display: grid;
+  gap: clamp(2rem, 6vw, 4rem);
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  align-items: center;
 }
 
 .focus-hero__eyebrow {
   text-transform: uppercase;
   letter-spacing: 0.32em;
-  font-size: 0.85rem;
-  color: rgba(148, 163, 184, 0.7);
+  font-size: 0.9rem;
+  color: rgba(71, 85, 105, 0.7);
 }
 
 .focus-hero__title {
   margin: 0;
-  font-size: clamp(2.8rem, 6vw, 4.6rem);
-  line-height: 1.08;
+  font-size: clamp(2.6rem, 5vw, 3.8rem);
+  line-height: 1.1;
+  color: #0f172a;
 }
 
 .focus-hero__subtitle {
   margin: 0;
-  font-size: clamp(1.05rem, 2.8vw, 1.4rem);
+  font-size: clamp(1.05rem, 2.6vw, 1.4rem);
   line-height: 1.7;
-  color: rgba(203, 213, 225, 0.82);
+  color: rgba(71, 85, 105, 0.85);
+}
+
+.focus-hero__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.85rem;
+  margin-top: 0.5rem;
 }
 
 .focus-hero__cta {
-  align-self: flex-start;
-  padding: 1rem 2.3rem;
   border-radius: 999px;
-  border: none;
-  font-size: 1.05rem;
+  padding: 0.95rem 2.3rem;
+  font-size: 1rem;
   font-weight: 600;
-  color: #f8fafc;
   cursor: pointer;
-  background: linear-gradient(135deg, rgba(37, 99, 235, 0.95) 0%, rgba(30, 64, 175, 0.95) 100%);
-  box-shadow: 0 24px 54px rgba(37, 99, 235, 0.35);
-  transition: transform 0.25s ease, box-shadow 0.25s ease;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease, color 0.2s ease;
 }
 
-.focus-hero__cta:hover,
-.focus-hero__cta:focus-visible {
-  transform: translateY(-3px);
-  box-shadow: 0 36px 72px rgba(30, 64, 175, 0.45);
+.focus-hero__cta--primary {
+  border: none;
+  color: #ffffff;
+  background: linear-gradient(135deg, #2fb4d4 0%, #3b82f6 100%);
+  box-shadow: 0 24px 54px rgba(63, 131, 248, 0.25);
+}
+
+.focus-hero__cta--primary:hover,
+.focus-hero__cta--primary:focus-visible {
+  transform: translateY(-2px);
+  box-shadow: 0 30px 64px rgba(63, 131, 248, 0.3);
+}
+
+.focus-hero__cta--ghost {
+  border: 1px solid rgba(15, 23, 42, 0.15);
+  color: #0f172a;
+  background: rgba(255, 255, 255, 0.8);
+  box-shadow: 0 12px 32px rgba(15, 23, 42, 0.08);
+}
+
+.focus-hero__cta--ghost:hover,
+.focus-hero__cta--ghost:focus-visible {
+  transform: translateY(-2px);
+  background: rgba(255, 255, 255, 0.95);
+}
+
+.focus-hero__text {
+  display: grid;
+  gap: 1.4rem;
+  max-width: 520px;
+}
+
+.focus-hero__visual {
+  position: relative;
+  width: min(420px, 65vw);
+  aspect-ratio: 1 / 1;
+  margin-inline: auto;
+  border-radius: 50%;
+  background: radial-gradient(circle at center, #d6e7f4 0%, #ecf4fb 45%, #f7f5ee 100%);
+  box-shadow: 0 30px 80px rgba(15, 23, 42, 0.15);
+  overflow: hidden;
+}
+
+.focus-hero__visual::after {
+  content: '';
+  position: absolute;
+  inset: 8%;
+  border-radius: 50%;
+  border: 1px dashed rgba(148, 163, 184, 0.35);
+}
+
+.focus-hero__visual-core {
+  position: absolute;
+  inset: 26%;
+  border-radius: 50%;
+  background: radial-gradient(circle at 40% 40%, rgba(15, 118, 110, 0.18), rgba(15, 118, 110, 0));
+  border: 1px solid rgba(148, 163, 184, 0.3);
+  display: grid;
+  place-items: center;
+  box-shadow: inset 0 30px 60px rgba(15, 23, 42, 0.08);
+}
+
+.focus-hero__visual-core span {
+  width: 42%;
+  aspect-ratio: 1 / 1;
+  border-radius: 50%;
+  background: radial-gradient(circle at 50% 35%, rgba(148, 163, 184, 0.4), rgba(99, 102, 241, 0));
+  box-shadow: inset 0 -18px 36px rgba(15, 23, 42, 0.12);
+}
+
+.focus-hero__orbit {
+  position: absolute;
+  inset: 12%;
+  border-radius: 50%;
+  border: 1px dashed rgba(15, 118, 110, 0.25);
+}
+
+.focus-hero__orbit--outer {
+  inset: 4%;
+  border-color: rgba(59, 130, 246, 0.22);
+}
+
+.focus-hero__orbit--inner {
+  inset: 22%;
+  border-color: rgba(125, 211, 252, 0.35);
+}
+
+.focus-hero__orbit span {
+  position: absolute;
+  width: 14px;
+  height: 14px;
+  border-radius: 50%;
+  background: rgba(63, 131, 248, 0.85);
+  box-shadow: 0 10px 22px rgba(63, 131, 248, 0.28);
+}
+
+.focus-hero__orbit span:nth-child(1) {
+  top: -7px;
+  left: 50%;
+  transform: translateX(-50%);
+}
+
+.focus-hero__orbit span:nth-child(2) {
+  right: -7px;
+  top: 50%;
+  transform: translateY(-50%);
+}
+
+.focus-hero__orbit span:nth-child(3) {
+  bottom: -7px;
+  left: 22%;
+}
+
+.focus-hero__orbit--inner span {
+  width: 10px;
+  height: 10px;
+  background: rgba(14, 165, 233, 0.9);
+  box-shadow: 0 10px 18px rgba(14, 165, 233, 0.25);
 }
 
 .focus-daily {
@@ -119,18 +252,14 @@
   padding: clamp(1.75rem, 4vw, 2.3rem);
   display: grid;
   gap: 1rem;
-  backdrop-filter: blur(12px);
-  box-shadow: 0 26px 58px rgba(2, 6, 23, 0.45);
-}
-
-.focus-daily__cue {
-  background: linear-gradient(160deg, rgba(15, 23, 42, 0.78), rgba(30, 41, 59, 0.9));
+  background: rgba(255, 255, 255, 0.95);
   border: 1px solid rgba(148, 163, 184, 0.2);
+  box-shadow: 0 24px 56px rgba(15, 23, 42, 0.08);
 }
 
 .focus-quick-start {
-  background: linear-gradient(150deg, rgba(37, 99, 235, 0.38), rgba(15, 118, 110, 0.4));
-  border: 1px solid rgba(56, 189, 248, 0.35);
+  background: linear-gradient(150deg, rgba(229, 244, 250, 0.95), rgba(255, 255, 255, 0.98));
+  border-color: rgba(59, 130, 246, 0.25);
   overflow: hidden;
 }
 
@@ -139,7 +268,7 @@
   font-size: 0.85rem;
   letter-spacing: 0.24em;
   text-transform: uppercase;
-  color: rgba(148, 163, 184, 0.75);
+  color: rgba(71, 85, 105, 0.65);
 }
 
 .focus-daily__cue h3,
@@ -147,13 +276,14 @@
   margin: 0;
   font-size: clamp(1.4rem, 3.5vw, 1.8rem);
   line-height: 1.35;
-  color: #f8fafc;
+  color: #0f172a;
 }
 
 .focus-daily__cue p,
 .focus-quick-start p {
   margin: 0;
   line-height: 1.6;
+  color: rgba(71, 85, 105, 0.85);
 }
 
 .focus-daily__reminder {
@@ -163,7 +293,7 @@
   align-items: center;
   padding: 1rem 1.25rem;
   border-radius: 18px;
-  background: rgba(30, 41, 59, 0.65);
+  background: rgba(241, 247, 253, 0.9);
   border: 1px solid rgba(148, 163, 184, 0.25);
 }
 
@@ -174,7 +304,7 @@
 .focus-daily__reminder-time {
   margin: 0;
   font-weight: 600;
-  color: rgba(148, 163, 184, 0.85);
+  color: rgba(71, 85, 105, 0.7);
   text-transform: uppercase;
   letter-spacing: 0.12em;
   font-size: 0.8rem;
@@ -182,12 +312,12 @@
 
 .focus-daily__reminder-text {
   margin: 0;
-  color: rgba(226, 232, 240, 0.85);
+  color: rgba(71, 85, 105, 0.85);
   font-size: 0.95rem;
 }
 
 .focus-quick-start__memory {
-  color: rgba(226, 232, 240, 0.88);
+  color: rgba(71, 85, 105, 0.85);
 }
 
 .focus-quick-start__actions {
@@ -201,17 +331,17 @@
   padding: 0.95rem 1.75rem;
   font-size: 1rem;
   font-weight: 600;
-  color: #f8fafc;
+  color: #ffffff;
   cursor: pointer;
-  background: linear-gradient(135deg, rgba(15, 118, 110, 0.95), rgba(37, 99, 235, 0.95));
-  box-shadow: 0 28px 56px rgba(15, 118, 110, 0.35);
+  background: linear-gradient(135deg, #2fb4d4 0%, #3b82f6 100%);
+  box-shadow: 0 24px 54px rgba(63, 131, 248, 0.25);
   transition: transform 0.2s ease, box-shadow 0.2s ease;
 }
 
 .focus-quick-start__button:hover,
 .focus-quick-start__button:focus-visible {
   transform: translateY(-2px);
-  box-shadow: 0 32px 64px rgba(15, 118, 110, 0.4);
+  box-shadow: 0 30px 64px rgba(63, 131, 248, 0.3);
 }
 
 .focus-quick-start__button:disabled {
@@ -221,30 +351,30 @@
 }
 
 .focus-quick-start__status {
-  color: rgba(226, 232, 240, 0.9);
+  color: rgba(71, 85, 105, 0.85);
   font-size: 0.95rem;
 }
 
 .focus-quick-start__complete {
-  border: 1px solid rgba(226, 232, 240, 0.4);
+  border: 1px solid rgba(59, 130, 246, 0.25);
   border-radius: 999px;
   padding: 0.85rem 1.5rem;
-  background: rgba(15, 23, 42, 0.25);
-  color: #f8fafc;
+  background: rgba(236, 245, 254, 0.9);
+  color: #0f172a;
   font-weight: 600;
   cursor: pointer;
-  transition: background 0.2s ease, border-color 0.2s ease;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
 }
 
 .focus-quick-start__complete:hover,
 .focus-quick-start__complete:focus-visible {
-  background: rgba(15, 23, 42, 0.4);
-  border-color: rgba(226, 232, 240, 0.6);
+  transform: translateY(-2px);
+  box-shadow: 0 16px 32px rgba(59, 130, 246, 0.2);
 }
 
 .focus-quick-start__hint {
   font-size: 0.9rem;
-  color: rgba(226, 232, 240, 0.82);
+  color: rgba(71, 85, 105, 0.75);
 }
 
 .focus-quick-start__options {
@@ -254,11 +384,11 @@
 }
 
 .focus-quick-start__chip {
-  border: 1px solid rgba(226, 232, 240, 0.3);
+  border: 1px solid rgba(148, 163, 184, 0.35);
   border-radius: 999px;
   padding: 0.55rem 1.1rem;
-  background: rgba(15, 23, 42, 0.2);
-  color: #f8fafc;
+  background: rgba(244, 248, 253, 0.9);
+  color: #1f2937;
   display: grid;
   gap: 0.15rem;
   font-size: 0.95rem;
@@ -271,14 +401,14 @@
   font-size: 0.7rem;
   letter-spacing: 0.12em;
   text-transform: uppercase;
-  color: rgba(148, 163, 184, 0.85);
+  color: rgba(71, 85, 105, 0.7);
 }
 
 .focus-quick-start__chip.is-active {
-  background: rgba(15, 23, 42, 0.5);
-  border-color: rgba(56, 189, 248, 0.65);
+  background: rgba(220, 238, 255, 0.95);
+  border-color: rgba(59, 130, 246, 0.45);
   transform: translateY(-2px);
-  box-shadow: 0 16px 32px rgba(15, 23, 42, 0.45);
+  box-shadow: 0 18px 36px rgba(59, 130, 246, 0.22);
 }
 
 .focus-quick-start__chip.is-mini::after {
@@ -286,7 +416,7 @@
   font-size: 0.65rem;
   text-transform: uppercase;
   letter-spacing: 0.2em;
-  color: rgba(148, 163, 184, 0.75);
+  color: rgba(71, 85, 105, 0.6);
   justify-self: start;
 }
 
@@ -294,8 +424,8 @@
   margin-top: 1.1rem;
   padding: 1rem 1.3rem;
   border-radius: 20px;
-  background: linear-gradient(135deg, rgba(56, 189, 248, 0.3), rgba(99, 102, 241, 0.3));
-  color: rgba(248, 250, 252, 0.95);
+  background: linear-gradient(135deg, rgba(148, 197, 231, 0.45), rgba(186, 230, 253, 0.5));
+  color: #0f172a;
   text-align: center;
   display: grid;
   gap: 0.45rem;
@@ -307,7 +437,7 @@
   font-size: 0.75rem;
   text-transform: uppercase;
   letter-spacing: 0.24em;
-  color: rgba(226, 232, 240, 0.75);
+  color: rgba(71, 85, 105, 0.65);
 }
 
 .focus-celebration__icon {
@@ -319,7 +449,7 @@
   padding: clamp(3rem, 10vw, 5rem) clamp(1.5rem, 8vw, 6rem);
   display: grid;
   gap: clamp(2rem, 6vw, 3rem);
-  background: linear-gradient(180deg, rgba(15, 23, 42, 0.82) 0%, rgba(15, 23, 42, 0.92) 100%);
+  background: linear-gradient(180deg, rgba(236, 244, 250, 0.8) 0%, rgba(253, 250, 244, 0.85) 100%);
 }
 
 .focus-progress__grid {
@@ -329,23 +459,24 @@
 }
 
 .focus-progress__card {
-  background: linear-gradient(160deg, rgba(30, 41, 59, 0.85), rgba(15, 23, 42, 0.95));
+  background: rgba(255, 255, 255, 0.96);
   border-radius: 28px;
   padding: clamp(1.75rem, 4vw, 2.3rem);
   border: 1px solid rgba(148, 163, 184, 0.2);
   display: grid;
   gap: 1rem;
-  box-shadow: 0 24px 60px rgba(2, 6, 23, 0.5);
+  box-shadow: 0 24px 60px rgba(15, 23, 42, 0.08);
 }
 
 .focus-progress__card h3 {
   margin: 0;
   font-size: clamp(1.4rem, 3.5vw, 1.8rem);
+  color: #0f172a;
 }
 
 .focus-progress__card p {
   margin: 0;
-  color: rgba(226, 232, 240, 0.85);
+  color: rgba(71, 85, 105, 0.85);
   line-height: 1.6;
 }
 
@@ -353,7 +484,7 @@
   position: relative;
   height: 12px;
   border-radius: 999px;
-  background: rgba(30, 41, 59, 0.6);
+  background: rgba(226, 232, 240, 0.7);
   overflow: hidden;
 }
 
@@ -361,13 +492,13 @@
   position: absolute;
   inset: 0;
   border-radius: inherit;
-  background: linear-gradient(135deg, rgba(37, 99, 235, 0.8), rgba(15, 118, 110, 0.9));
+  background: linear-gradient(135deg, rgba(59, 130, 246, 0.85), rgba(45, 212, 191, 0.9));
   transition: width 0.3s ease;
 }
 
 .focus-progress__goal {
   font-size: 0.8rem;
-  color: rgba(148, 163, 184, 0.75);
+  color: rgba(71, 85, 105, 0.65);
   text-transform: uppercase;
   letter-spacing: 0.16em;
 }
@@ -384,12 +515,12 @@
 .focus-progress__day {
   padding: 0.9rem;
   border-radius: 18px;
-  background: rgba(15, 23, 42, 0.55);
+  background: rgba(244, 248, 253, 0.95);
   border: 1px solid rgba(148, 163, 184, 0.2);
   display: grid;
   gap: 0.4rem;
   justify-items: center;
-  color: rgba(226, 232, 240, 0.8);
+  color: rgba(71, 85, 105, 0.85);
   font-size: 0.9rem;
 }
 
@@ -404,18 +535,18 @@
 }
 
 .focus-progress__day.is-complete {
-  background: linear-gradient(140deg, rgba(37, 99, 235, 0.55), rgba(15, 118, 110, 0.55));
-  border-color: rgba(37, 99, 235, 0.6);
-  box-shadow: 0 18px 36px rgba(15, 118, 110, 0.35);
-  color: #f8fafc;
+  background: linear-gradient(140deg, rgba(59, 130, 246, 0.55), rgba(45, 212, 191, 0.55));
+  border-color: rgba(59, 130, 246, 0.4);
+  box-shadow: 0 18px 36px rgba(59, 130, 246, 0.18);
+  color: #0f172a;
 }
 
 @keyframes focus-celebration-glow {
   from {
-    box-shadow: 0 18px 40px rgba(37, 99, 235, 0.4);
+    box-shadow: 0 18px 40px rgba(59, 130, 246, 0.25);
   }
   to {
-    box-shadow: 0 26px 60px rgba(56, 189, 248, 0.5);
+    box-shadow: 0 26px 60px rgba(125, 211, 252, 0.35);
   }
 }
 
@@ -446,27 +577,28 @@
 .focus-section-header h2 {
   margin: 0;
   font-size: clamp(2.1rem, 4vw, 3rem);
+  color: #0f172a;
 }
 
 .focus-section-header p {
   margin: 0;
   font-size: 1.1rem;
   line-height: 1.65;
-  color: rgba(226, 232, 240, 0.78);
+  color: rgba(71, 85, 105, 0.8);
 }
 
 .focus-section-eyebrow {
   font-size: 0.95rem;
   text-transform: uppercase;
   letter-spacing: 0.18em;
-  color: rgba(148, 163, 184, 0.75);
+  color: rgba(100, 116, 139, 0.7);
 }
 
 .focus-routine {
   padding: clamp(3rem, 10vw, 6rem) clamp(1.5rem, 8vw, 6rem);
   display: grid;
   gap: clamp(2.5rem, 8vw, 4.5rem);
-  background: linear-gradient(180deg, rgba(15, 23, 42, 0.75) 0%, rgba(15, 23, 42, 0.6) 100%);
+  background: linear-gradient(180deg, rgba(249, 250, 251, 0.85) 0%, rgba(236, 244, 250, 0.75) 100%);
 }
 
 .focus-timeline {
@@ -481,26 +613,25 @@
   position: absolute;
   inset: 15% 0 auto;
   height: 2px;
-  background: linear-gradient(90deg, rgba(59, 130, 246, 0) 0%, rgba(59, 130, 246, 0.25) 50%, rgba(59, 130, 246, 0) 100%);
+  background: linear-gradient(90deg, rgba(59, 130, 246, 0) 0%, rgba(148, 163, 184, 0.35) 50%, rgba(59, 130, 246, 0) 100%);
   pointer-events: none;
 }
 
 .focus-timeline__card {
-  background: linear-gradient(160deg, rgba(30, 41, 59, 0.85), rgba(15, 23, 42, 0.92));
+  background: rgba(255, 255, 255, 0.96);
   border-radius: 28px;
   padding: 2rem;
   display: grid;
   gap: 1.1rem;
   position: relative;
-  box-shadow: 0 28px 70px rgba(2, 6, 23, 0.55);
-  backdrop-filter: blur(12px);
-  border: 1px solid rgba(59, 130, 246, 0.15);
+  box-shadow: 0 24px 56px rgba(15, 23, 42, 0.08);
+  border: 1px solid rgba(148, 163, 184, 0.2);
   transition: transform 0.3s ease, box-shadow 0.3s ease;
 }
 
 .focus-timeline__card.is-expanded {
   transform: translateY(-8px);
-  box-shadow: 0 36px 82px rgba(2, 6, 23, 0.6);
+  box-shadow: 0 32px 72px rgba(15, 23, 42, 0.12);
 }
 
 .focus-timeline__toggle {
@@ -516,7 +647,7 @@
 }
 
 .focus-timeline__toggle:focus-visible {
-  outline: 2px solid rgba(56, 189, 248, 0.5);
+  outline: 2px solid rgba(59, 130, 246, 0.45);
   outline-offset: 6px;
   border-radius: 16px;
 }
@@ -528,7 +659,7 @@
   place-items: center;
   font-size: 2rem;
   border-radius: 20px;
-  background: linear-gradient(140deg, rgba(56, 189, 248, 0.25) 0%, rgba(37, 99, 235, 0.35) 100%);
+  background: linear-gradient(140deg, rgba(191, 219, 254, 0.7) 0%, rgba(125, 211, 252, 0.6) 100%);
 }
 
 .focus-timeline__label {
@@ -536,20 +667,21 @@
   font-size: 0.9rem;
   text-transform: uppercase;
   letter-spacing: 0.18em;
-  color: rgba(148, 163, 184, 0.75);
+  color: rgba(100, 116, 139, 0.7);
 }
 
 .focus-timeline__toggle h3 {
   margin: 0.35rem 0 0;
   font-size: 1.6rem;
   line-height: 1.3;
+  color: #0f172a;
 }
 
 .focus-timeline__chevron {
   width: 12px;
   height: 12px;
-  border-right: 2px solid rgba(226, 232, 240, 0.35);
-  border-bottom: 2px solid rgba(226, 232, 240, 0.35);
+  border-right: 2px solid rgba(100, 116, 139, 0.35);
+  border-bottom: 2px solid rgba(100, 116, 139, 0.35);
   transform: rotate(45deg);
   transition: transform 0.3s ease;
 }
@@ -562,7 +694,7 @@
   margin: 0;
   font-size: 1rem;
   line-height: 1.6;
-  color: rgba(226, 232, 240, 0.82);
+  color: rgba(71, 85, 105, 0.85);
 }
 
 .focus-timeline__details {
@@ -578,7 +710,7 @@
 .focus-timeline__details-title {
   font-weight: 600;
   margin: 0;
-  color: #f8fafc;
+  color: #0f172a;
 }
 
 .focus-timeline__details ul {
@@ -592,10 +724,10 @@
   margin: 0;
   padding: 1rem 1.4rem;
   border-radius: 20px;
-  background: rgba(30, 64, 175, 0.35);
+  background: rgba(226, 242, 255, 0.85);
   display: grid;
   gap: 0.5rem;
-  color: rgba(226, 232, 240, 0.85);
+  color: rgba(15, 23, 42, 0.8);
   font-size: 0.95rem;
 }
 
@@ -604,13 +736,15 @@
   font-size: 0.85rem;
   text-transform: uppercase;
   letter-spacing: 0.12em;
+  color: rgba(71, 85, 105, 0.7);
 }
+
 
 .focus-notifications {
   padding: clamp(3rem, 10vw, 6rem) clamp(1.5rem, 8vw, 6rem);
   display: grid;
   gap: clamp(2.5rem, 8vw, 4.5rem);
-  background: linear-gradient(180deg, rgba(15, 23, 42, 0.78) 0%, rgba(2, 6, 23, 0.9) 100%);
+  background: linear-gradient(180deg, rgba(236, 244, 250, 0.75) 0%, rgba(255, 255, 255, 0.9) 100%);
 }
 
 .focus-notifications__switcher {
@@ -624,25 +758,26 @@
   border: none;
   border-radius: 20px;
   padding: 0.9rem 1.5rem;
-  background: rgba(15, 23, 42, 0.7);
-  color: rgba(226, 232, 240, 0.8);
+  background: rgba(255, 255, 255, 0.9);
+  color: #0f172a;
   font-weight: 600;
   display: grid;
   gap: 0.2rem;
   text-align: left;
   cursor: pointer;
+  box-shadow: 0 16px 36px rgba(15, 23, 42, 0.08);
   transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
 }
 
 .focus-notifications__chip small {
   font-size: 0.75rem;
   font-weight: 500;
-  color: rgba(148, 163, 184, 0.75);
+  color: rgba(100, 116, 139, 0.75);
 }
 
 .focus-notifications__chip.is-active {
-  background: linear-gradient(135deg, rgba(37, 99, 235, 0.65) 0%, rgba(15, 118, 110, 0.55) 100%);
-  box-shadow: 0 24px 48px rgba(15, 118, 110, 0.3);
+  background: linear-gradient(135deg, rgba(191, 219, 254, 0.95) 0%, rgba(125, 211, 252, 0.9) 100%);
+  box-shadow: 0 24px 48px rgba(148, 163, 184, 0.25);
   transform: translateY(-4px);
 }
 
@@ -651,14 +786,16 @@
   justify-content: center;
 }
 
+
 .focus-phone {
   width: clamp(260px, 40vw, 320px);
   border-radius: 36px;
   padding: 1.5rem 1.25rem;
-  background: linear-gradient(160deg, rgba(59, 130, 246, 0.08) 0%, rgba(15, 118, 110, 0.22) 100%);
-  box-shadow: 0 30px 70px rgba(2, 6, 23, 0.6);
+  background: linear-gradient(160deg, rgba(191, 219, 254, 0.35) 0%, rgba(236, 254, 255, 0.8) 100%);
+  box-shadow: 0 30px 70px rgba(15, 23, 42, 0.12);
   position: relative;
 }
+
 
 .focus-phone__notch {
   position: absolute;
@@ -667,23 +804,26 @@
   transform: translateX(-50%);
   width: 40%;
   height: 14px;
-  background: rgba(148, 163, 184, 0.35);
+  background: rgba(148, 163, 184, 0.4);
   border-radius: 0 0 12px 12px;
 }
 
+
 .focus-phone__screen {
-  background: linear-gradient(180deg, #0f172a 0%, #1e293b 100%);
+  background: linear-gradient(180deg, #f8fafc 0%, #e2f5ff 100%);
   border-radius: 24px;
   padding: 1.4rem 1rem;
   display: grid;
   gap: 1rem;
   min-height: 360px;
-  border: 1px solid rgba(148, 163, 184, 0.12);
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  box-shadow: inset 0 12px 30px rgba(59, 130, 246, 0.08);
 }
+
 
 .focus-phone__status {
   font-weight: 600;
-  color: rgba(148, 163, 184, 0.8);
+  color: rgba(71, 85, 105, 0.7);
   text-align: center;
   letter-spacing: 0.12em;
   text-transform: uppercase;
@@ -698,54 +838,16 @@
   gap: 0.75rem;
 }
 
+
 .focus-phone__message {
   padding: 0.85rem 1rem;
   border-radius: 18px;
-  background: linear-gradient(135deg, rgba(59, 130, 246, 0.3) 0%, rgba(13, 148, 136, 0.3) 100%);
-  color: rgba(248, 250, 252, 0.92);
+  background: rgba(191, 219, 254, 0.9);
+  color: #0f172a;
   font-size: 0.95rem;
   line-height: 1.4;
-  box-shadow: 0 18px 36px rgba(2, 6, 23, 0.55);
+  box-shadow: 0 18px 36px rgba(59, 130, 246, 0.18);
   animation: focus-pop 0.4s ease;
-}
-
-.focus-science {
-  position: relative;
-  margin: clamp(3rem, 10vw, 6rem) clamp(1.5rem, 8vw, 6rem) clamp(4rem, 10vw, 8rem);
-  border-radius: 36px;
-  overflow: hidden;
-  background: url('https://images.unsplash.com/photo-1525182008055-f88b95ff7980?auto=format&fit=crop&w=1600&q=80') center/cover;
-  color: #fff;
-}
-
-.focus-science__overlay {
-  position: absolute;
-  inset: 0;
-  background: linear-gradient(160deg, rgba(15, 23, 42, 0.78) 0%, rgba(15, 23, 42, 0.6) 40%, rgba(15, 23, 42, 0.35) 100%);
-}
-
-.focus-science__content {
-  position: relative;
-  padding: clamp(3rem, 8vw, 5rem);
-  display: grid;
-  gap: 1rem;
-  max-width: min(720px, 90vw);
-}
-
-.focus-science__content p {
-  margin: 0;
-  font-size: 1.1rem;
-  line-height: 1.75;
-  color: rgba(241, 245, 249, 0.9);
-}
-
-@keyframes focus-sunrise {
-  from {
-    transform: translateX(-50%) translateY(12px);
-  }
-  to {
-    transform: translateX(-50%) translateY(-12px);
-  }
 }
 
 @keyframes focus-fade-in {
@@ -789,16 +891,12 @@
     padding-bottom: clamp(4rem, 12vw, 6rem);
   }
 
-  .focus-hero__background {
-    background: linear-gradient(180deg, rgba(15, 23, 42, 0.96) 0%, rgba(15, 23, 42, 0.88) 65%, rgba(2, 6, 23, 0.92) 100%);
+  .focus-hero__body {
+    grid-template-columns: 1fr;
   }
 
-  .focus-hero__sun {
-    width: clamp(240px, 70vw, 320px);
-  }
-
-  .focus-hero__ocean {
-    height: clamp(200px, 40vw, 280px);
+  .focus-hero__visual {
+    width: min(320px, 80vw);
   }
 
   .focus-daily {
@@ -809,6 +907,10 @@
   .focus-progress {
     padding-inline: clamp(1.1rem, 8vw, 2rem);
   }
+
+  .focus-notifications {
+    padding-inline: clamp(1.1rem, 8vw, 2rem);
+  }
 }
 
 @media (max-width: 580px) {
@@ -816,9 +918,14 @@
     gap: 1.4rem;
   }
 
-  .focus-hero__cta {
+  .focus-hero__actions {
     width: 100%;
-    justify-content: center;
+    flex-direction: column;
+  }
+
+  .focus-hero__cta {
+    flex: 1 1 auto;
+    text-align: center;
   }
 
   .focus-timeline__card {

--- a/src/screens/FocusRoutineScreen.tsx
+++ b/src/screens/FocusRoutineScreen.tsx
@@ -154,6 +154,7 @@ const dailyFocus = {
 
 export default function FocusRoutineScreen() {
   const routineSectionRef = useRef<HTMLElement | null>(null)
+  const notificationsSectionRef = useRef<HTMLElement | null>(null)
   const celebrationTimeoutRef = useRef<number | null>(null)
   const storedProgressRef = useRef<StoredProgress | null>(null)
   const [expandedPhase, setExpandedPhase] = useState<RoutinePhase['id'] | null>('morning')
@@ -205,6 +206,10 @@ export default function FocusRoutineScreen() {
 
   const handleScrollToRoutine = () => {
     routineSectionRef.current?.scrollIntoView({ behavior: 'smooth' })
+  }
+
+  const handleScrollToNotifications = () => {
+    notificationsSectionRef.current?.scrollIntoView({ behavior: 'smooth' })
   }
 
   const selectedQuickStart =
@@ -319,23 +324,67 @@ export default function FocusRoutineScreen() {
   return (
     <div className="focus-page">
       <header className="focus-hero">
-        <div className="focus-hero__background" aria-hidden="true">
-          <div className="focus-hero__sun" />
-          <div className="focus-hero__horizon" />
-          <div className="focus-hero__ocean" />
-        </div>
+        <div className="focus-hero__background" aria-hidden="true" />
 
         <div className="focus-hero__content">
-          <BrandLogo as="div" align="left" size={56} wordmarkSize="2.4rem" wordmarkText="Fokus" />
-          <span className="focus-hero__eyebrow">Din dag med Fokus</span>
-          <h1 className="focus-hero__title">Skab balance i din hverdag med personlige rutiner</h1>
-          <p className="focus-hero__subtitle">
-            Fokus guider dig gennem dagen med små øjeblikke af ro og klarhed. Fra solopgang til nat ro hjælper vi dig
-            med at skabe rytme, nærvær og fornyet energi.
-          </p>
-          <button type="button" className="focus-hero__cta" onClick={handleScrollToRoutine}>
-            Se din daglige rutine
-          </button>
+          <div className="focus-hero__topbar">
+            <BrandLogo as="div" align="left" size={56} wordmarkSize="2.4rem" wordmarkText="Fokus" />
+            <button type="button" className="focus-hero__mode-toggle" aria-label="Aktivér Calm Mode">
+              <span aria-hidden="true" className="focus-hero__mode-icon">
+                🍃
+              </span>
+              Calm Mode
+            </button>
+          </div>
+
+          <div className="focus-hero__body">
+            <div className="focus-hero__text">
+              <span className="focus-hero__eyebrow">Train Your Mind</span>
+              <h1 className="focus-hero__title">
+                Games, meditations, and routines to help you focus better every day.
+              </h1>
+              <p className="focus-hero__subtitle">
+                Strengthen your mental clarity and emotional balance through personalized daily practices.
+              </p>
+              <div className="focus-hero__actions">
+                <button
+                  type="button"
+                  className="focus-hero__cta focus-hero__cta--primary"
+                  onClick={handleScrollToRoutine}
+                >
+                  Start Training
+                </button>
+                <button
+                  type="button"
+                  className="focus-hero__cta focus-hero__cta--ghost"
+                  onClick={handleScrollToNotifications}
+                >
+                  Learn More
+                </button>
+              </div>
+            </div>
+
+            <div className="focus-hero__visual" aria-hidden="true">
+              <div className="focus-hero__visual-core">
+                <span />
+              </div>
+              <div className="focus-hero__orbit focus-hero__orbit--outer">
+                <span />
+                <span />
+                <span />
+              </div>
+              <div className="focus-hero__orbit">
+                <span />
+                <span />
+                <span />
+              </div>
+              <div className="focus-hero__orbit focus-hero__orbit--inner">
+                <span />
+                <span />
+                <span />
+              </div>
+            </div>
+          </div>
         </div>
       </header>
 
@@ -508,7 +557,11 @@ export default function FocusRoutineScreen() {
         </div>
       </section>
 
-      <section className="focus-notifications" aria-labelledby="notifications-heading">
+      <section
+        className="focus-notifications"
+        aria-labelledby="notifications-heading"
+        ref={notificationsSectionRef}
+      >
         <header className="focus-section-header">
           <span className="focus-section-eyebrow">🔔 Små påmindelser, stor effekt</span>
           <h2 id="notifications-heading">Se hvordan Fokus guider dig gennem dagen</h2>
@@ -548,22 +601,6 @@ export default function FocusRoutineScreen() {
               </ul>
             </div>
           </div>
-        </div>
-      </section>
-
-      <section className="focus-science" aria-labelledby="science-heading">
-        <div className="focus-science__overlay" />
-        <div className="focus-science__content">
-          <span className="focus-section-eyebrow">🌊 Videnskaben bag Fokus</span>
-          <h2 id="science-heading">Ro, evidens og nærvær i samme oplevelse</h2>
-          <p>
-            Fokus bygger på principper fra kognitiv træning, søvnforskning og mindfulness. Små daglige vaner – som lys,
-            bevægelse og taknemmelighed – har dokumenteret effekt på koncentration og velvære.
-          </p>
-          <p>
-            Med en rytme, der følger naturens tempo, hjælper Fokus dig med at skabe varige vaner. Resultatet er en hverdag
-            med mere klarhed, overskud og ro.
-          </p>
         </div>
       </section>
     </div>


### PR DESCRIPTION
## Summary
- restyle the Focus landing hero with a calm-mode header, new CTA buttons, and an orbit graphic inspired by the provided concept
- refresh routine, progress, and notification sections with a lighter color palette and card treatments to match the updated landing design
- remove the "Videnskaben bag Fokus" block and add a smooth scroll target for the secondary hero action

## Testing
- npm run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690f8f6f0bf8832fbc4ce48729d68e5b)