### PR TITLE
Remove gradient overlay from login landing background

### DIFF
--- a/src/screens/LoginScreen.css
+++ b/src/screens/LoginScreen.css
@@ -4,8 +4,7 @@
   flex-direction: column;
   justify-content: center;
   color: #0f172a;
-  background-image: linear-gradient(180deg, rgba(255, 255, 255, 0.82) 0%, rgba(255, 255, 255, 0.68) 40%, rgba(255, 255, 255, 0.45) 100%),
-    url('/landingpage_bg.jpg');
+  background-image: url('/landingpage_bg.jpg');
   background-size: cover;
   background-position: center;
   background-repeat: no-repeat;


### PR DESCRIPTION
## Summary
- remove the linear gradient overlay from the landing screen background so only the background image is shown

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690fa3d6df80832fa58fd21ce78925ab)