### PR TITLE
Update Puzzle Blox header and mobile layout

### DIFF
--- a/src/games/puzzleblox/PuzzleBloxGame.css
+++ b/src/games/puzzleblox/PuzzleBloxGame.css
@@ -112,12 +112,10 @@
 .puzzle-blox__header {
   display: flex;
   align-items: center;
-  gap: 1rem;
-  background: linear-gradient(120deg, #34d399, #22d3ee);
-  border-radius: 1.25rem;
-  padding: 0.85rem 1.15rem;
-  color: #0f172a;
-  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.65);
+  justify-content: center;
+  padding: 0.25rem 0 0.5rem;
+  color: inherit;
+  text-align: center;
 }
 
 .puzzle-blox__header h1 {
@@ -125,39 +123,6 @@
   margin: 0;
   font-weight: 700;
   letter-spacing: -0.01em;
-}
-
-.puzzle-blox__back-button {
-  background: rgba(15, 23, 42, 0.12);
-  border: 1px solid rgba(255, 255, 255, 0.65);
-  border-radius: 999px;
-  color: #0f172a;
-  cursor: pointer;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  font-size: 0.95rem;
-  font-weight: 600;
-  padding: 0.45rem 1rem;
-  gap: 0.4rem;
-  box-shadow: 0 8px 20px rgba(14, 165, 233, 0.2);
-  transition: transform 0.2s ease, box-shadow 0.2s ease;
-}
-
-.puzzle-blox__back-button:hover {
-  transform: translateY(-1px);
-  box-shadow: 0 10px 28px rgba(14, 165, 233, 0.28);
-}
-
-.puzzle-blox__back-button:focus-visible {
-  outline: 3px solid rgba(79, 70, 229, 0.4);
-  outline-offset: 3px;
-}
-
-.puzzle-blox__back-button:disabled {
-  opacity: 0.6;
-  cursor: default;
-  box-shadow: 0 6px 14px rgba(14, 165, 233, 0.18);
 }
 
 .puzzle-blox__layout {
@@ -169,13 +134,13 @@
 
 .puzzle-blox__boards {
   display: grid;
-  gap: clamp(1rem, 3vw, 1.5rem);
-  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: clamp(0.85rem, 2.5vw, 1.5rem);
+  grid-template-columns: 1fr;
 }
 
-@media (max-width: 820px) {
+@media (min-width: 880px) {
   .puzzle-blox__boards {
-    grid-template-columns: 1fr;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 }
 
@@ -184,7 +149,7 @@
   border-radius: 1.35rem;
   border: 1px solid rgba(148, 163, 184, 0.18);
   box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.6), 0 18px 40px rgba(148, 163, 184, 0.22);
-  padding: clamp(1rem, 2.5vw, 1.5rem);
+  padding: clamp(0.85rem, 2.3vw, 1.5rem);
   display: flex;
   flex-direction: column;
   gap: 0.85rem;
@@ -210,6 +175,12 @@
 .puzzle-blox__grid {
   display: grid;
   gap: clamp(0.45rem, 1vw, 0.6rem);
+}
+
+@media (max-width: 640px) {
+  .puzzle-blox__grid {
+    gap: clamp(0.35rem, 2vw, 0.5rem);
+  }
 }
 
 .puzzle-blox__cell {

--- a/src/games/puzzleblox/PuzzleBloxGame.tsx
+++ b/src/games/puzzleblox/PuzzleBloxGame.tsx
@@ -210,16 +210,6 @@ export default function PuzzleBloxGame({ onExit }: PuzzleBloxGameProps) {
   return (
     <div className="puzzle-blox">
       <header className="puzzle-blox__header">
-        <button
-          type="button"
-          className="puzzle-blox__back-button"
-          onClick={onExit}
-          aria-label="Tilbage til forsiden"
-          disabled={!onExit}
-        >
-          <span aria-hidden="true">←</span>
-          Tilbage
-        </button>
         <h1>Puzzle Blox</h1>
       </header>
 


### PR DESCRIPTION
## Summary
- remove the back button and gradient styling from the Puzzle Blox header
- adjust the Puzzle Blox board layout so both grids remain visible on small screens
- fine-tune panel and grid spacing to reduce vertical bulk on mobile devices

## Testing
- npm run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690fa686e58c832f843a5768395875db)