### PR TITLE
Make overview hero dismissible and reduce prominence

### DIFF
--- a/src/screens/OverviewScreen.css
+++ b/src/screens/OverviewScreen.css
@@ -6,17 +6,18 @@
 
 .overview__hero {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
   align-items: center;
-  gap: clamp(1.5rem, 4vw, 3rem);
-  padding: clamp(2rem, 5vw, 3.5rem);
-  border-radius: clamp(1.5rem, 4vw, 2.5rem);
+  gap: clamp(1.25rem, 3vw, 2.25rem);
+  padding: clamp(1.5rem, 4vw, 2.5rem);
+  padding-top: clamp(2rem, 5vw, 3rem);
+  border-radius: clamp(1.5rem, 4vw, 2.25rem);
   position: relative;
   overflow: hidden;
-  background: linear-gradient(135deg, rgba(59, 130, 246, 0.22), rgba(14, 165, 233, 0.15));
-  border: 1px solid rgba(148, 163, 184, 0.18);
-  box-shadow: 0 30px 70px rgba(15, 23, 42, 0.18);
-  backdrop-filter: blur(8px);
+  background: linear-gradient(135deg, rgba(59, 130, 246, 0.2), rgba(14, 165, 233, 0.12));
+  border: 1px solid rgba(148, 163, 184, 0.16);
+  box-shadow: 0 22px 48px rgba(15, 23, 42, 0.16);
+  backdrop-filter: blur(6px);
 }
 
 body[data-theme='focus'] .overview__hero {
@@ -37,14 +38,14 @@ body[data-theme='focus'] .overview__hero {
   align-self: flex-start;
   display: inline-flex;
   align-items: center;
-  gap: 0.5rem;
-  padding: 0.35rem 0.8rem;
+  gap: 0.35rem;
+  padding: 0.25rem 0.65rem;
   border-radius: 999px;
-  background: rgba(255, 255, 255, 0.38);
+  background: rgba(255, 255, 255, 0.35);
   color: #0369a1;
-  font-size: 0.75rem;
+  font-size: 0.7rem;
   font-weight: 600;
-  letter-spacing: 0.08em;
+  letter-spacing: 0.06em;
   text-transform: uppercase;
 }
 
@@ -66,14 +67,14 @@ body[data-theme='focus'] .overview__hero-badge {
 }
 
 .overview__hero h1 {
-  font-size: clamp(2.4rem, 6vw, 3.4rem);
+  font-size: clamp(2rem, 5vw, 2.8rem);
   margin: 0;
   line-height: 1.1;
 }
 
 .overview__hero p {
   margin: 0;
-  font-size: clamp(1.05rem, 2.5vw, 1.2rem);
+  font-size: clamp(1rem, 2vw, 1.1rem);
   color: var(--app-muted);
 }
 
@@ -87,13 +88,13 @@ body[data-theme='focus'] .overview__hero-badge {
   position: relative;
   display: grid;
   place-items: center;
-  min-height: 280px;
+  min-height: 220px;
 }
 
 .overview__planet {
   position: relative;
-  width: clamp(220px, 32vw, 320px);
-  height: clamp(220px, 32vw, 320px);
+  width: clamp(180px, 28vw, 260px);
+  height: clamp(180px, 28vw, 260px);
   border-radius: 50%;
   background: radial-gradient(circle at 30% 30%, rgba(148, 197, 255, 0.45), rgba(59, 130, 246, 0.15));
   display: grid;
@@ -159,6 +160,45 @@ body[data-theme='focus'] .overview__orbit::after {
   width: 210%;
   height: 210%;
   animation-duration: 36s;
+}
+
+.overview__hero-close {
+  position: absolute;
+  top: 0.75rem;
+  right: 0.75rem;
+  width: 2rem;
+  height: 2rem;
+  border-radius: 999px;
+  border: none;
+  background: rgba(15, 23, 42, 0.08);
+  color: inherit;
+  font-size: 1.25rem;
+  font-weight: 600;
+  line-height: 1;
+  display: grid;
+  place-items: center;
+  cursor: pointer;
+  transition: background 0.2s ease, color 0.2s ease;
+}
+
+.overview__hero-close:hover,
+.overview__hero-close:focus-visible {
+  background: rgba(15, 23, 42, 0.18);
+}
+
+.overview__hero-close:focus-visible {
+  outline: 2px solid currentColor;
+  outline-offset: 2px;
+}
+
+body[data-theme='focus'] .overview__hero-close {
+  background: rgba(15, 23, 42, 0.32);
+  color: #e0f2fe;
+}
+
+body[data-theme='focus'] .overview__hero-close:hover,
+body[data-theme='focus'] .overview__hero-close:focus-visible {
+  background: rgba(30, 64, 175, 0.65);
 }
 
 @keyframes overviewOrbit {

--- a/src/screens/OverviewScreen.tsx
+++ b/src/screens/OverviewScreen.tsx
@@ -1,3 +1,4 @@
+import { useState } from 'react'
 import { Link } from 'react-router-dom'
 import './OverviewScreen.css'
 
@@ -53,41 +54,53 @@ const sections: OverviewSection[] = [
 ]
 
 export default function OverviewScreen() {
+  const [isHeroVisible, setHeroVisible] = useState(true)
+
   return (
     <div className="overview">
-      <section className="overview__hero">
-        <div className="overview__hero-copy">
-          <div className="overview__hero-badge">
-            <span className="overview__hero-badge-text overview__hero-badge-text--calm">
-              Calm Mode
-            </span>
-            <span className="overview__hero-badge-text overview__hero-badge-text--focus">
-              Focus Mode
-            </span>
+      {isHeroVisible && (
+        <section className="overview__hero">
+          <button
+            type="button"
+            className="overview__hero-close"
+            aria-label="Skjul introduktion"
+            onClick={() => setHeroVisible(false)}
+          >
+            ×
+          </button>
+          <div className="overview__hero-copy">
+            <div className="overview__hero-badge">
+              <span className="overview__hero-badge-text overview__hero-badge-text--calm">
+                Calm Mode
+              </span>
+              <span className="overview__hero-badge-text overview__hero-badge-text--focus">
+                Focus Mode
+              </span>
+            </div>
+            <h1>Train Your Mind</h1>
+            <p>
+              Games, meditations, and routines to help you focus better every day. Strengthen
+              your mental clarity and emotional balance through personalized daily practices.
+            </p>
+            <div className="overview__actions">
+              <Link to="/overview/games" className="button--primary">
+                Start Training
+              </Link>
+              <Link to="/rutines" className="button--ghost">
+                Learn More
+              </Link>
+            </div>
           </div>
-          <h1>Train Your Mind</h1>
-          <p>
-            Games, meditations, and routines to help you focus better every day. Strengthen your
-            mental clarity and emotional balance through personalized daily practices.
-          </p>
-          <div className="overview__actions">
-            <Link to="/overview/games" className="button--primary">
-              Start Training
-            </Link>
-            <Link to="/rutines" className="button--ghost">
-              Learn More
-            </Link>
-          </div>
-        </div>
 
-        <div className="overview__visual" aria-hidden="true">
-          <div className="overview__planet">
-            <span className="overview__orbit overview__orbit--one" />
-            <span className="overview__orbit overview__orbit--two" />
-            <span className="overview__orbit overview__orbit--three" />
+          <div className="overview__visual" aria-hidden="true">
+            <div className="overview__planet">
+              <span className="overview__orbit overview__orbit--one" />
+              <span className="overview__orbit overview__orbit--two" />
+              <span className="overview__orbit overview__orbit--three" />
+            </div>
           </div>
-        </div>
-      </section>
+        </section>
+      )}
 
       <section className="overview__sections">
         <div className="overview__section-header">


### PR DESCRIPTION
## Summary
- shrink the overview hero spacing and visual scale so the calm/focus toggle stays visible
- add a close control that lets users dismiss the landing hero when they no longer need it

## Testing
- npm run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690fae8d6828832fa333ad1c046bd3c9)