### PR TITLE
Remove header theme toggle to restrict mode switching to menu

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -91,25 +91,6 @@ function AppChrome({ mode, onSetMode, children, onBack, canGoBack = true }: AppC
           </div>
 
           <div className="app-shell__actions">
-            <div className="app-shell__mode-switch" role="group" aria-label="Skift tema">
-              <button
-                type="button"
-                className={`app-shell__mode-option ${mode === 'calm' ? 'is-active' : ''}`}
-                onClick={() => handleModeSelect('calm')}
-                aria-pressed={mode === 'calm'}
-              >
-                Calm
-              </button>
-              <button
-                type="button"
-                className={`app-shell__mode-option ${mode === 'focus' ? 'is-active' : ''}`}
-                onClick={() => handleModeSelect('focus')}
-                aria-pressed={mode === 'focus'}
-              >
-                Focus
-              </button>
-            </div>
-
             <button
               type="button"
               className="app-shell__burger"


### PR DESCRIPTION
## Summary
- remove the calm/focus mode toggle from the top bar so it is only available inside the burger menu

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690fb095f44c832fbfbfda3787f60fd1)