### PR TITLE
Fix Puzzle Blox scroll on small screens

### DIFF
--- a/src/games/puzzleblox/PuzzleBloxGame.css
+++ b/src/games/puzzleblox/PuzzleBloxGame.css
@@ -12,6 +12,12 @@
   overflow: hidden;
 }
 
+@media (max-width: 768px) {
+  .puzzle-blox {
+    overflow: visible;
+  }
+}
+
 .puzzle-blox__content {
   display: grid;
   gap: clamp(1.5rem, 3vw, 2rem);


### PR DESCRIPTION
## Summary
- allow the Puzzle Blox container to overflow on screens narrower than 768px so the game can scroll fully on mobile

## Testing
- not run (CSS-only change)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690fb0cd1240832fbc142261c99eab59)