### PR TITLE
Allow mobile scrolling in Puzzle Blox screen

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -84,6 +84,17 @@ body[data-theme='focus'] {
   z-index: 1;
 }
 
+@media (max-width: 768px) {
+  .app {
+    align-items: flex-start;
+  }
+
+  .app__inner {
+    width: 100%;
+    align-self: stretch;
+  }
+}
+
 .app-shell__top {
   display: flex;
   align-items: center;

--- a/src/games/puzzleblox/PuzzleBloxGame.css
+++ b/src/games/puzzleblox/PuzzleBloxGame.css
@@ -12,6 +12,12 @@
   overflow: hidden;
 }
 
+@media (max-width: 768px) {
+  .puzzle-blox {
+    overflow: visible;
+  }
+}
+
 .puzzle-blox__content {
   display: grid;
   gap: clamp(1.5rem, 3vw, 2rem);

--- a/src/index.css
+++ b/src/index.css
@@ -25,6 +25,7 @@ body {
   height: 100%;
   isolation: isolate;
   overflow-y: auto;
+  -webkit-overflow-scrolling: touch;
 }
 
 #root > * {


### PR DESCRIPTION
## Summary
- align the application shell to the top on narrow screens so game layouts can extend beyond the viewport
- enable touch scrolling on the fixed root container to restore vertical panning on mobile devices

## Testing
- not run (CSS-only changes)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690fb0cd1240832fbc142261c99eab59)