### PR TITLE
Allow Puzzle Blox board to be fully visible

### DIFF
--- a/src/games/puzzleblox/PuzzleBloxGame.css
+++ b/src/games/puzzleblox/PuzzleBloxGame.css
@@ -9,13 +9,7 @@
   gap: clamp(1rem, 2.5vw, 1.75rem);
   backdrop-filter: blur(10px);
   position: relative;
-  overflow: hidden;
-}
-
-@media (max-width: 768px) {
-  .puzzle-blox {
-    overflow: visible;
-  }
+  overflow: visible;
 }
 
 .puzzle-blox__content {


### PR DESCRIPTION
## Summary
- let the Puzzle Blox card overflow so the full board stays visible on all screen sizes

## Testing
- npm run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690fb83680f8832fbad93233fab30980)