### PR TITLE
Add configurable word search mini-game

### DIFF
--- a/public/gameIcons_svg/word_search_game_svg.svg
+++ b/public/gameIcons_svg/word_search_game_svg.svg
@@ -1,0 +1,33 @@
+<svg width="200" height="200" viewBox="0 0 200 200" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="grid" x1="0" y1="0" x2="200" y2="200" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#5B6BFF" />
+      <stop offset="1" stop-color="#00E6A7" />
+    </linearGradient>
+  </defs>
+  <rect x="16" y="16" width="168" height="168" rx="28" fill="#0F172A" />
+  <rect x="26" y="26" width="148" height="148" rx="22" fill="#0C1C3F" stroke="url(#grid)" stroke-width="4" />
+  <g stroke="#1F3B7A" stroke-width="3">
+    <line x1="50" y1="50" x2="150" y2="50" />
+    <line x1="50" y1="82" x2="150" y2="82" />
+    <line x1="50" y1="114" x2="150" y2="114" />
+    <line x1="50" y1="146" x2="150" y2="146" />
+    <line x1="50" y1="50" x2="50" y2="146" />
+    <line x1="82" y1="50" x2="82" y2="146" />
+    <line x1="114" y1="50" x2="114" y2="146" />
+    <line x1="146" y1="50" x2="146" y2="146" />
+  </g>
+  <g font-family="'Space Grotesk', 'Inter', sans-serif" font-weight="700" fill="#E6EDFF" font-size="20" text-anchor="middle">
+    <text x="66" y="75">F</text>
+    <text x="98" y="75">O</text>
+    <text x="130" y="75">K</text>
+    <text x="66" y="107">U</text>
+    <text x="98" y="107">S</text>
+    <text x="130" y="107">R</text>
+    <text x="66" y="139">O</text>
+    <text x="98" y="139">L</text>
+    <text x="130" y="139">G</text>
+  </g>
+  <circle cx="140" cy="60" r="26" fill="rgba(91, 107, 255, 0.22)" stroke="#7CE8C8" stroke-width="4" />
+  <path d="M160 86L176 102" stroke="#7CE8C8" stroke-width="8" stroke-linecap="round" />
+</svg>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -25,6 +25,7 @@ import SpatialSweepScreen from './screens/SpatialSweepScreen'
 import MindMathScreen from './screens/MindMathScreen'
 import FocusFlowScreen from './screens/FocusFlowScreen'
 import WordWeaveScreen from './screens/WordWeaveScreen'
+import WordSearchScreen from './screens/WordSearchScreen'
 import BrandLogo from './components/BrandLogo'
 
 type ThemeMode = 'calm' | 'focus'
@@ -342,6 +343,7 @@ function App() {
         <Route path="mind-math" element={<MindMathScreen />} />
         <Route path="focus-flow" element={<FocusFlowScreen />} />
         <Route path="word-weave" element={<WordWeaveScreen />} />
+        <Route path="word-search" element={<WordSearchScreen />} />
         <Route path="reaction-test" element={<ReactionTestScreen />} />
         <Route path="meditation">
           <Route index element={<MeditationHubScreen />} />

--- a/src/games/wordsearch/WordSearchGame.css
+++ b/src/games/wordsearch/WordSearchGame.css
@@ -1,0 +1,257 @@
+.word-search {
+  display: grid;
+  gap: clamp(1.5rem, 3vw, 2rem);
+  color: var(--app-foreground);
+}
+
+.word-search__panel {
+  display: grid;
+  gap: 1rem;
+  padding: 1.25rem;
+  border-radius: 1.25rem;
+  background: linear-gradient(135deg, #f7f8ff 0%, #eef3ff 50%, #ffffff 100%);
+  border: 1px solid #e2e8ff;
+  box-shadow: 0 10px 40px rgba(15, 23, 42, 0.08);
+}
+
+.word-search__eyebrow {
+  letter-spacing: 0.08em;
+  font-size: 0.9rem;
+  color: #5b6b92;
+  margin: 0 0 0.5rem;
+  text-transform: uppercase;
+}
+
+.word-search__controls {
+  display: grid;
+  gap: 1rem;
+}
+
+.word-search__control {
+  display: grid;
+  gap: 0.5rem;
+  font-weight: 600;
+  color: #0f172a;
+}
+
+.word-search__control span {
+  font-size: 0.95rem;
+}
+
+.word-search__control-row {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.word-search__control input[type='range'] {
+  flex: 1;
+  accent-color: #5b6bff;
+}
+
+.word-search__control textarea {
+  width: 100%;
+  min-height: 80px;
+  padding: 0.75rem;
+  border-radius: 0.75rem;
+  border: 1px solid #d8def0;
+  background: #fff;
+  font-family: inherit;
+  resize: vertical;
+  transition: border-color 0.2s ease;
+}
+
+.word-search__control textarea:focus {
+  outline: none;
+  border-color: #5b6bff;
+  box-shadow: 0 0 0 3px rgba(91, 107, 255, 0.15);
+}
+
+.word-search__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.word-search__badge {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.35rem 0.7rem;
+  border-radius: 999px;
+  background: #0b1b4a;
+  color: #e6edff;
+  font-size: 0.9rem;
+  font-weight: 700;
+}
+
+.word-search__badge--muted {
+  background: #e6ebff;
+  color: #1b2f66;
+}
+
+.word-search__status {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  gap: 0.75rem;
+  background: #0f172a;
+  color: #e8edff;
+  border-radius: 0.95rem;
+  padding: 0.85rem 1rem;
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.06);
+}
+
+.word-search__status div {
+  display: grid;
+  gap: 0.2rem;
+}
+
+.word-search__status p {
+  margin: 0;
+  font-size: 0.85rem;
+  color: #c5d0ff;
+}
+
+.word-search__status strong {
+  font-size: 1.4rem;
+}
+
+.word-search__layout {
+  display: grid;
+  gap: clamp(1rem, 2vw, 1.5rem);
+  align-items: start;
+}
+
+@media (min-width: 1040px) {
+  .word-search__layout {
+    grid-template-columns: minmax(0, 1.6fr) minmax(320px, 0.8fr);
+  }
+}
+
+.word-search__grid-wrapper {
+  background: linear-gradient(180deg, rgba(14, 21, 46, 0.88), rgba(16, 45, 87, 0.85));
+  color: #f8fbff;
+  border-radius: 1.25rem;
+  padding: clamp(1rem, 2vw, 1.25rem);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  box-shadow: 0 15px 50px rgba(15, 23, 42, 0.35);
+}
+
+.word-search__grid {
+  display: grid;
+  gap: 0.35rem;
+  background: rgba(255, 255, 255, 0.05);
+  padding: 0.6rem;
+  border-radius: 0.9rem;
+}
+
+.word-search__cell {
+  position: relative;
+  aspect-ratio: 1 / 1;
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  border-radius: 0.5rem;
+  background: rgba(255, 255, 255, 0.08);
+  color: #f2f6ff;
+  font-size: clamp(0.85rem, 1.4vw, 1.1rem);
+  font-weight: 700;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  transition: transform 0.08s ease, border-color 0.15s ease, background 0.15s ease;
+}
+
+.word-search__cell:hover {
+  transform: translateY(-1px);
+  border-color: rgba(255, 255, 255, 0.5);
+}
+
+.word-search__cell.is-active {
+  background: linear-gradient(145deg, rgba(255, 255, 255, 0.35), rgba(111, 138, 255, 0.6));
+  color: #0c1a3a;
+  border-color: rgba(111, 138, 255, 0.9);
+  box-shadow: 0 0 0 2px rgba(111, 138, 255, 0.35);
+}
+
+.word-search__cell.is-found {
+  background: linear-gradient(135deg, rgba(83, 232, 185, 0.85), rgba(48, 167, 133, 0.9));
+  color: #052e2d;
+  border-color: rgba(36, 180, 142, 0.9);
+  box-shadow: 0 0 0 2px rgba(36, 180, 142, 0.5);
+}
+
+.word-search__cell span {
+  pointer-events: none;
+}
+
+.word-search__message {
+  margin: 0.75rem 0 0;
+  color: #dbe6ff;
+  font-size: 0.95rem;
+  letter-spacing: 0.01em;
+}
+
+.word-search__wordlist {
+  background: #0b1333;
+  color: #f0f4ff;
+  border-radius: 1.2rem;
+  padding: 1.1rem 1.2rem;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  box-shadow: 0 10px 40px rgba(4, 10, 38, 0.55);
+}
+
+.word-search__wordlist-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 0.75rem;
+  margin-bottom: 0.65rem;
+}
+
+.word-search__wordlist-header p {
+  margin: 0;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: #bfc8f8;
+  font-weight: 700;
+}
+
+.word-search__wordlist ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 0.4rem;
+}
+
+.word-search__wordlist li {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 0.65rem 0.7rem;
+  border-radius: 0.75rem;
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  font-weight: 700;
+  letter-spacing: 0.05em;
+}
+
+.word-search__wordlist li.is-found {
+  background: rgba(83, 232, 185, 0.12);
+  color: #5be8b9;
+  text-decoration: line-through;
+  border-color: rgba(83, 232, 185, 0.4);
+}
+
+.word-search__wordlist li span:last-child {
+  font-size: 1rem;
+}
+
+@media (max-width: 720px) {
+  .word-search__actions {
+    flex-direction: column;
+  }
+
+  .word-search__cell {
+    font-size: 0.9rem;
+  }
+}

--- a/src/games/wordsearch/WordSearchGame.tsx
+++ b/src/games/wordsearch/WordSearchGame.tsx
@@ -1,0 +1,397 @@
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import './WordSearchGame.css'
+
+type Coord = { row: number; col: number }
+
+type WordPlacement = {
+  word: string
+  positions: Coord[]
+  found: boolean
+}
+
+type WordSearchGameProps = {
+  startSignal?: number
+  onFinished?: (summary: { found: number; total: number; gridSize: number; mistakes: number }) => void
+}
+
+const LETTERS = 'ABCDEFGHIJKLMNOPQRSTUVWXYZÆØÅ'
+const DEFAULT_GRID_SIZE = 10
+const DEFAULT_WORDS = [
+  'FOKUS',
+  'BALANCE',
+  'HUKOMMELSE',
+  'LOGIK',
+  'RO',
+  'STRATEGI',
+  'FLOW',
+  'RUTINE',
+  'TEMPO',
+  'MØNSTER',
+]
+
+const directions: Coord[] = [
+  { row: 0, col: 1 },
+  { row: 0, col: -1 },
+  { row: 1, col: 0 },
+  { row: -1, col: 0 },
+  { row: 1, col: 1 },
+  { row: 1, col: -1 },
+  { row: -1, col: 1 },
+  { row: -1, col: -1 },
+]
+
+function randomLetter() {
+  return LETTERS[Math.floor(Math.random() * LETTERS.length)]
+}
+
+function normalizeWords(input: string, gridSize: number) {
+  const rawWords = input
+    .split(/[\n,;]+/)
+    .map((word) => word.replace(/[^A-Za-zÆØÅæøå]/g, '').toUpperCase())
+    .filter(Boolean)
+
+  const sanitized = rawWords.filter((word) => word.length >= 2 && word.length <= gridSize)
+
+  if (sanitized.length === 0) {
+    return DEFAULT_WORDS.filter((word) => word.length <= gridSize)
+  }
+
+  return sanitized
+}
+
+function canPlaceWord(grid: string[][], word: string, start: Coord, direction: Coord) {
+  const size = grid.length
+  for (let index = 0; index < word.length; index += 1) {
+    const row = start.row + direction.row * index
+    const col = start.col + direction.col * index
+    if (row < 0 || col < 0 || row >= size || col >= size) return false
+    const cell = grid[row][col]
+    if (cell !== '' && cell !== word[index]) return false
+  }
+  return true
+}
+
+function placeWord(grid: string[][], word: string): Coord[] | null {
+  const size = grid.length
+  const maxAttempts = 200
+
+  for (let attempt = 0; attempt < maxAttempts; attempt += 1) {
+    const direction = directions[Math.floor(Math.random() * directions.length)]
+    const rowMin = direction.row < 0 ? word.length - 1 : 0
+    const rowMax = direction.row > 0 ? size - word.length : size - 1
+    const colMin = direction.col < 0 ? word.length - 1 : 0
+    const colMax = direction.col > 0 ? size - word.length : size - 1
+
+    if (rowMax < rowMin || colMax < colMin) continue
+
+    const start: Coord = {
+      row: rowMin + Math.floor(Math.random() * (rowMax - rowMin + 1)),
+      col: colMin + Math.floor(Math.random() * (colMax - colMin + 1)),
+    }
+
+    if (!canPlaceWord(grid, word, start, direction)) continue
+
+    const positions: Coord[] = []
+    for (let index = 0; index < word.length; index += 1) {
+      const row = start.row + direction.row * index
+      const col = start.col + direction.col * index
+      grid[row][col] = word[index]
+      positions.push({ row, col })
+    }
+
+    return positions
+  }
+
+  return null
+}
+
+function buildPuzzle(words: string[], gridSize: number) {
+  const grid: string[][] = Array.from({ length: gridSize }, () => Array.from({ length: gridSize }, () => ''))
+  const placements: WordPlacement[] = []
+
+  const shuffledWords = [...words].sort(() => Math.random() - 0.5)
+
+  for (const word of shuffledWords) {
+    const positions = placeWord(grid, word)
+    if (positions) {
+      placements.push({ word, positions, found: false })
+    }
+  }
+
+  for (let row = 0; row < gridSize; row += 1) {
+    for (let col = 0; col < gridSize; col += 1) {
+      if (grid[row][col] === '') {
+        grid[row][col] = randomLetter()
+      }
+    }
+  }
+
+  return { grid, placements }
+}
+
+function getLineBetween(start: Coord, end: Coord): Coord[] | null {
+  const rowDiff = end.row - start.row
+  const colDiff = end.col - start.col
+
+  if (rowDiff === 0 && colDiff === 0) {
+    return [start]
+  }
+
+  const isStraight = rowDiff === 0 || colDiff === 0 || Math.abs(rowDiff) === Math.abs(colDiff)
+  if (!isStraight) return null
+
+  const stepRow = Math.sign(rowDiff)
+  const stepCol = Math.sign(colDiff)
+  const length = Math.max(Math.abs(rowDiff), Math.abs(colDiff))
+
+  const path: Coord[] = []
+  for (let index = 0; index <= length; index += 1) {
+    path.push({ row: start.row + stepRow * index, col: start.col + stepCol * index })
+  }
+  return path
+}
+
+export default function WordSearchGame({ startSignal, onFinished }: WordSearchGameProps) {
+  const [gridSize, setGridSize] = useState(DEFAULT_GRID_SIZE)
+  const [wordInput, setWordInput] = useState(DEFAULT_WORDS.join(', '))
+  const [grid, setGrid] = useState<string[][]>([])
+  const [placements, setPlacements] = useState<WordPlacement[]>([])
+  const [activePath, setActivePath] = useState<Coord[]>([])
+  const [dragStart, setDragStart] = useState<Coord | null>(null)
+  const [clickStart, setClickStart] = useState<Coord | null>(null)
+  const [isDragging, setIsDragging] = useState(false)
+  const [message, setMessage] = useState('Markér ord vandret, lodret eller diagonalt.')
+  const [mistakes, setMistakes] = useState(0)
+  const [foundCells, setFoundCells] = useState<Set<string>>(new Set())
+
+  const activePathKeys = useMemo(() => new Set(activePath.map((coord) => `${coord.row}-${coord.col}`)), [activePath])
+  const foundCount = useMemo(() => placements.filter((placement) => placement.found).length, [placements])
+
+  const applySettings = useCallback(() => {
+    const normalizedWords = normalizeWords(wordInput, gridSize)
+    const { grid: newGrid, placements: newPlacements } = buildPuzzle(normalizedWords, gridSize)
+    setGrid(newGrid)
+    setPlacements(newPlacements)
+    setActivePath([])
+    setDragStart(null)
+    setClickStart(null)
+    setIsDragging(false)
+    setMessage('Markér ord vandret, lodret eller diagonalt.')
+    setMistakes(0)
+    setFoundCells(new Set())
+  }, [gridSize, wordInput])
+
+  useEffect(() => {
+    applySettings()
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
+
+  useEffect(() => {
+    if (startSignal === undefined || startSignal === 0) return
+    applySettings()
+  }, [applySettings, startSignal])
+
+  const commitSelection = (path: Coord[] | null) => {
+    if (!path || path.length === 0) {
+      setMessage('Markering skal være en lige linje.')
+      setActivePath([])
+      setClickStart(null)
+      setDragStart(null)
+      return
+    }
+
+    const wordForward = path.map((coord) => grid[coord.row][coord.col]).join('')
+    const wordBackward = wordForward.split('').reverse().join('')
+    const matchIndex = placements.findIndex(
+      (placement) => !placement.found && (placement.word === wordForward || placement.word === wordBackward),
+    )
+
+    if (matchIndex >= 0) {
+      const matched = placements[matchIndex]
+      const updatedPlacements = placements.map((placement, index) =>
+        index === matchIndex ? { ...placement, found: true } : placement,
+      )
+      const updatedFoundCells = new Set(foundCells)
+      matched.positions.forEach((coord) => updatedFoundCells.add(`${coord.row}-${coord.col}`))
+
+      setPlacements(updatedPlacements)
+      setFoundCells(updatedFoundCells)
+      setMessage(`Fundet: ${matched.word}`)
+
+      const nextFound = foundCount + 1
+      if (nextFound === updatedPlacements.length) {
+        onFinished?.({
+          found: nextFound,
+          total: updatedPlacements.length,
+          gridSize,
+          mistakes,
+        })
+        setMessage('Alle ord fundet!')
+      }
+    } else {
+      setMistakes((prev) => prev + 1)
+      setMessage('Ikke på ordlisten. Prøv igen.')
+    }
+
+    setActivePath([])
+    setClickStart(null)
+    setDragStart(null)
+  }
+
+  const handleCellMouseDown = (coord: Coord) => {
+    setIsDragging(true)
+    setDragStart(coord)
+    setClickStart(null)
+    setActivePath([coord])
+  }
+
+  const handleCellMouseEnter = (coord: Coord) => {
+    if (!isDragging || !dragStart) return
+    const path = getLineBetween(dragStart, coord)
+    setActivePath(path ?? [dragStart])
+  }
+
+  const handleCellMouseUp = (coord: Coord) => {
+    if (dragStart) {
+      commitSelection(getLineBetween(dragStart, coord))
+    }
+    setIsDragging(false)
+  }
+
+  const handleCellClick = (coord: Coord) => {
+    if (isDragging) return
+    if (!clickStart) {
+      setClickStart(coord)
+      setActivePath([coord])
+      setMessage('Vælg slutpunkt i samme linje for at bekræfte.')
+      return
+    }
+
+    commitSelection(getLineBetween(clickStart, coord))
+  }
+
+  const handleLeaveGrid = () => {
+    setIsDragging(false)
+    setActivePath([])
+    setDragStart(null)
+    setClickStart(null)
+  }
+
+  const remaining = placements.length - foundCount
+
+  return (
+    <div className="word-search">
+      <div className="word-search__panel">
+        <div>
+          <p className="word-search__eyebrow">Konfiguration</p>
+          <div className="word-search__controls">
+            <label className="word-search__control">
+              <span>Gitterstørrelse</span>
+              <div className="word-search__control-row">
+                <input
+                  type="range"
+                  min={6}
+                  max={14}
+                  value={gridSize}
+                  onChange={(event) => setGridSize(Number(event.target.value))}
+                  aria-label="Vælg gitterstørrelse"
+                />
+                <span className="word-search__badge">
+                  {gridSize} × {gridSize}
+                </span>
+              </div>
+            </label>
+
+            <label className="word-search__control">
+              <span>Ordliste (kommasepareret)</span>
+              <textarea
+                value={wordInput}
+                onChange={(event) => setWordInput(event.target.value)}
+                rows={3}
+                aria-label="Redigér ordliste"
+              />
+            </label>
+
+            <div className="word-search__actions">
+              <button type="button" className="menu__primary-button" onClick={applySettings}>
+                Generér puslespil
+              </button>
+              <button type="button" className="menu__secondary-button" onClick={() => setWordInput(DEFAULT_WORDS.join(', '))}>
+                Gendan standardord
+              </button>
+            </div>
+          </div>
+        </div>
+
+        <div className="word-search__status">
+          <div>
+            <p>Ord fundet</p>
+            <strong>
+              {foundCount} / {placements.length || '-'}
+            </strong>
+          </div>
+          <div>
+            <p>Tilbage</p>
+            <strong>{placements.length === 0 ? '-' : remaining}</strong>
+          </div>
+          <div>
+            <p>Fejlmarkeringer</p>
+            <strong>{mistakes}</strong>
+          </div>
+        </div>
+      </div>
+
+      <div className="word-search__layout">
+        <div className="word-search__grid-wrapper" onMouseLeave={handleLeaveGrid}>
+          <div
+            className="word-search__grid"
+            style={{ gridTemplateColumns: `repeat(${gridSize}, minmax(28px, 1fr))` }}
+            role="grid"
+            aria-label={`Ordjagt i et ${gridSize} gange ${gridSize} gitter`}
+          >
+            {grid.map((row, rowIndex) =>
+              row.map((letter, colIndex) => {
+                const key = `${rowIndex}-${colIndex}`
+                const isFound = foundCells.has(key)
+                const isActive = activePathKeys.has(key)
+                return (
+                  <button
+                    key={key}
+                    type="button"
+                    className={`word-search__cell ${isFound ? 'is-found' : ''} ${isActive ? 'is-active' : ''}`}
+                    onMouseDown={() => handleCellMouseDown({ row: rowIndex, col: colIndex })}
+                    onMouseEnter={() => handleCellMouseEnter({ row: rowIndex, col: colIndex })}
+                    onMouseUp={() => handleCellMouseUp({ row: rowIndex, col: colIndex })}
+                    onClick={() => handleCellClick({ row: rowIndex, col: colIndex })}
+                    role="gridcell"
+                    aria-label={`Række ${rowIndex + 1}, kolonne ${colIndex + 1}, bogstav ${letter}`}
+                  >
+                    <span>{letter}</span>
+                  </button>
+                )
+              }),
+            )}
+          </div>
+          <p className="word-search__message" role="status">
+            {message}
+          </p>
+        </div>
+
+        <div className="word-search__wordlist" aria-label="Ord der skal findes">
+          <div className="word-search__wordlist-header">
+            <p>Ord der gemmer sig</p>
+            <span className="word-search__badge word-search__badge--muted">{placements.length} ord</span>
+          </div>
+          <ul>
+            {placements.map((placement) => (
+              <li key={placement.word} className={placement.found ? 'is-found' : ''}>
+                <span>{placement.word}</span>
+                {placement.found ? <span aria-hidden="true">✓</span> : null}
+              </li>
+            ))}
+          </ul>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/screens/OverviewGamesScreen.tsx
+++ b/src/screens/OverviewGamesScreen.tsx
@@ -160,6 +160,17 @@ const sections: GameSection[] = [
         badge: 'Ny',
         focus: 'Semantisk fleksibilitet',
       },
+      {
+        id: 'word-search',
+        title: 'Word Search',
+        description:
+          'Find skjulte ord i gitteret på kryds og tværs med fuld kontrol over størrelse og ordliste.',
+        ctaLabel: 'Åbn Word Search',
+        to: '/word-search',
+        icon: '/gameIcons_svg/word_search_game_svg.svg',
+        badge: 'Ny',
+        focus: 'Visuel scanning & mønstre',
+      },
     ],
   },
 ]

--- a/src/screens/WordSearchScreen.tsx
+++ b/src/screens/WordSearchScreen.tsx
@@ -1,0 +1,52 @@
+import { useMemo, useState } from 'react'
+import { useNavigate } from 'react-router-dom'
+import GameShell from '../components/GameShell'
+import WordSearchGame from '../games/wordsearch/WordSearchGame'
+import './NewCognitiveGames.css'
+
+export default function WordSearchScreen() {
+  const navigate = useNavigate()
+  const [isFinished, setIsFinished] = useState(false)
+  const [startSignal, setStartSignal] = useState(0)
+  const [summary, setSummary] = useState<{ found: number; total: number; gridSize: number; mistakes: number }>(
+    {
+      found: 0,
+      total: 0,
+      gridSize: 10,
+      mistakes: 0,
+    },
+  )
+
+  const summaryLines = useMemo(
+    () => [
+      `Fundet: ${summary.found} / ${summary.total}`,
+      `Gitter: ${summary.gridSize} × ${summary.gridSize}`,
+      `Fejlmarkeringer: ${summary.mistakes}`,
+    ],
+    [summary],
+  )
+
+  return (
+    <GameShell
+      title="Word Search"
+      subtitle="Find ordene på tværs af gitteret"
+      isFinished={isFinished}
+      summaryLines={summaryLines}
+      onRestart={() => {
+        setIsFinished(false)
+        setSummary({ found: 0, total: 0, gridSize: 10, mistakes: 0 })
+        setStartSignal((value) => value + 1)
+      }}
+      onExit={() => navigate('/overview/games')}
+      onReady={() => setStartSignal((value) => value + 1)}
+    >
+      <WordSearchGame
+        startSignal={startSignal}
+        onFinished={(result) => {
+          setSummary(result)
+          setIsFinished(true)
+        }}
+      />
+    </GameShell>
+  )
+}


### PR DESCRIPTION
## Summary
- add a configurable Word Search mini-game with grid generation, selection validation, and completion tracking
- style the new puzzle experience with immersive grid and found/selected highlights plus configuration controls
- expose the game via routing, overview listing, and a dedicated icon

## Testing
- npm run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692b1568a980832f978fd8e5276df88b)